### PR TITLE
Get rid of std::optional<ItemStack>

### DIFF
--- a/src/bpp_server/packet/handle_packet.cpp
+++ b/src/bpp_server/packet/handle_packet.cpp
@@ -7,9 +7,9 @@
 */
 
 #include "handle_packet.h"
+#include "../entities/entity_tracker.h"
 #include "entities/entity_item.h"
 #include "inventory/item_stack.h"
-#include "../entities/entity_tracker.h"
 
 namespace HandlePacket {
 void KeepAlive(Packet::KeepAlive& /*pkt*/, PlayerSession& session) {
@@ -175,7 +175,9 @@ void PlaceBlock(Packet::PlaceBlock& pkt, PlayerSession& session, WorldManager& w
 	if (pkt.face == PacketData::FaceDirection::USE_ITEM) {
 		GlobalLogger().info << "Tried to use item\n";
 		GlobalLogger().info << pkt.position << "\n";
+		return;
 	}
+
 	if (pkt.face == PacketData::FaceDirection::Y_MINUS)
 		pos.y -= 1;
 	if (pkt.face == PacketData::FaceDirection::Y_PLUS)
@@ -188,9 +190,18 @@ void PlaceBlock(Packet::PlaceBlock& pkt, PlayerSession& session, WorldManager& w
 		pos.x -= 1;
 	if (pkt.face == PacketData::FaceDirection::X_PLUS)
 		pos.x += 1;
+
+	ItemStack* heldItem = session.inventory.getHeldItem();
+	if (!heldItem)
+		return;
+
 	// Make sure the block id is valid for placement otherwise we will crash
-	if (pkt.item.id < BLOCK_MAX && (pkt.item.id >= 0))
-		world.setBlock({ pos.x, pos.y, pos.z }, BlockType(pkt.item.id.m_value), pkt.item.data);
+	if (heldItem->id >= BLOCK_MAX || (heldItem->id <= 0))
+		return;
+
+	BlockType blockId = static_cast<BlockType>(heldItem->id.m_value);
+	world.setBlock({ pos.x, pos.y, pos.z }, blockId, heldItem->data);
+	heldItem->decrementCount(1);
 }
 
 void SetHotbarSlot(Packet::SetHotbarSlot& pkt, PlayerSession& session) {
@@ -288,7 +299,8 @@ void InteractWithEntity(Packet::InteractWithEntity& /*pkt*/, PlayerSession& /*se
 	// TODO: attack / interact logic
 }
 
-void InteractWithBlock([[maybe_unused]] Packet::InteractWithBlock& pkt, [[maybe_unused]] PlayerSession& session, [[maybe_unused]] WorldManager& world) {}
+void InteractWithBlock([[maybe_unused]] Packet::InteractWithBlock& pkt, [[maybe_unused]] PlayerSession& session,
+                       [[maybe_unused]] WorldManager& world) {}
 
 void Animation(Packet::Animation& pkt, PlayerSession& session, EntityTracker& entityTracker) {
 	// Broadcast what we were sent to players who can see this player
@@ -298,7 +310,8 @@ void Animation(Packet::Animation& pkt, PlayerSession& session, EntityTracker& en
 	entityTracker.sendPacketToViewers(anim, anim.entity_id);
 }
 
-void PlayerAction([[maybe_unused]] Packet::PlayerAction& pkt, [[maybe_unused]] PlayerSession& session, [[maybe_unused]] EntityTracker& entityTracker) {
+void PlayerAction([[maybe_unused]] Packet::PlayerAction& pkt, [[maybe_unused]] PlayerSession& session,
+                  [[maybe_unused]] EntityTracker& entityTracker) {
 	// Broadcast what we were sent to players who can see this player
 }
 

--- a/src/bpp_server/packet/packet_utils.h
+++ b/src/bpp_server/packet/packet_utils.h
@@ -14,11 +14,7 @@ namespace PacketUtilities {
 inline void sendInventory(PlayerSession& session, WindowId windowId, Inventory inventory) {
 	std::vector<ItemStack> items;
 	for (auto& item : inventory.slots) {
-		if (!item.has_value()) {
-			items.emplace_back(ITEM_INVALID); // empty slot
-			continue;
-		}
-		items.emplace_back(item->id, item->count, item->data);
+		items.emplace_back(item.id, item.count, item.data);
 	}
 	Packet::FillContainer fc;
 	fc.window_id = windowId;

--- a/src/bpp_server/player_conn/player_session.h
+++ b/src/bpp_server/player_conn/player_session.h
@@ -10,6 +10,7 @@
 #include "../entities/entity_mp_player.h"
 #include "../entities/entity_tracker.h"
 #include "inventory/inventory_interaction.h"
+#include "items.h"
 #include "nbt/nbt.h"
 #include "networking/network_stream.h"
 #include "networking/packets.h"
@@ -220,7 +221,7 @@ struct PlayerSession {
 		// Save our current inventory
 		NetworkSlotId slotId = 0;
 		for (auto& item : inventory.slots) {
-			if (item.has_value()) {
+			if (item.id != ITEM_INVALID) {
 				Tag itemTag;
 				itemTag.type = TAG_COMPOUND;
 				itemTag.name = "";
@@ -231,15 +232,15 @@ struct PlayerSession {
 				Tag idTag;
 				idTag.type = TAG_SHORT;
 				idTag.name = "id";
-				idTag.shortValue = item->id;
+				idTag.shortValue = item.id;
 				Tag countTag;
 				countTag.type = TAG_BYTE;
 				countTag.name = "Count";
-				countTag.byteValue = item->count;
+				countTag.byteValue = item.count;
 				Tag damageTag;
 				damageTag.type = TAG_SHORT;
 				damageTag.name = "Damage";
-				damageTag.shortValue = item->data;
+				damageTag.shortValue = item.data;
 
 				itemTag.compound["Slot"] = slotTag;
 				itemTag.compound["id"] = idTag;

--- a/src/bpp_server/server.cpp
+++ b/src/bpp_server/server.cpp
@@ -365,9 +365,7 @@ void Server::tick() {
 		auto diffs2 = session->inventoryInteraction.tickDiff();
 		if (diffs2.size() <= 5) {
 			for (auto difference : diffs2) {
-				ItemStack invalid{ ITEM_INVALID };
-				ItemStack* item = difference.stack.has_value() ? &difference.stack.value() : &invalid;
-				PacketUtilities::sendSlot(*session, 0, difference.slot, item);
+				PacketUtilities::sendSlot(*session, 0, difference.slot, &difference.stack);
 			}
 		} else {
 			// Too many changes, just resend the whole inventory
@@ -388,8 +386,7 @@ void Server::tick() {
 		if (diffs.size() <= 5) {
 			for (auto difference : diffs) {
 				ItemStack invalid{ ITEM_INVALID };
-				ItemStack* item = difference.stack.has_value() ? &difference.stack.value() : &invalid;
-				PacketUtilities::sendSlot(*session, session->openWindowId, difference.slot, item);
+				PacketUtilities::sendSlot(*session, session->openWindowId, difference.slot, &difference.stack);
 			}
 		} else {
 			// Too many changes, just resend the whole inventory
@@ -433,7 +430,9 @@ void Server::disconnectClients() {
 	players.erase(std::remove_if(players.begin(), players.end(),
 	                             [&](const auto& s) {
 		                             if (!s->stream.isConnected()) {
-			                             if (s->entity) GlobalLogger().info << "Disconnected client " << s->username << " with entity id " << s->entity->id << "\n";
+			                             if (s->entity)
+				                             GlobalLogger().info << "Disconnected client " << s->username
+				                                                 << " with entity id " << s->entity->id << "\n";
 
 			                             if (s->connState == ConnectionState::Playing ||
 			                                 s->connState == ConnectionState::WaitingForSpawnChunks) {

--- a/src/bpp_shared/enums/items.h
+++ b/src/bpp_shared/enums/items.h
@@ -16,7 +16,7 @@ static constexpr int8_t ITEM_STACK_MAX = 64;
 
 enum Items : ItemId::Underlying {
 	ITEM_INVALID = -1,
-	ITEM_NONE = 0,
+	ITEM_NONE = 0, // This is usually not you want to use, use ITEM_INVALID instead
 
 	// Tools - Iron
 	ITEM_SHOVEL_IRON = 256,

--- a/src/bpp_shared/inventory/inventories.h
+++ b/src/bpp_shared/inventory/inventories.h
@@ -90,7 +90,7 @@ public:
 		return -1;
 	}
 
-	// Tries to "pickup" an item. Returns if it succeeded 
+	// Tries to "pickup" an item. Returns if it succeeded
 	// Not sure why vanilla does it in such a convoluted way
 	// but it is the way it is
 	bool pickupItem(ItemStack& stack) {
@@ -109,7 +109,7 @@ public:
 		}
 	}
 
-	// Returns whether we could merge an item stack without changing the inventory. 
+	// Returns whether we could merge an item stack without changing the inventory.
 	bool canMergeItemStackInInventory(ItemStack& stack, bool reverse = false, int startSlot = 0, int endSlot = -1) {
 		auto start = startSlot;
 		auto end = endSlot == -1 ? getSizeInventory() - 1 : endSlot;
@@ -214,7 +214,7 @@ struct InventoryDispenser : Inventory {
 	std::optional<ItemStack> getRandomStack() {
 		int chosen = -1, weight = 1;
 		for (int i = 0; i < 9; i++) {
-			if (!slots[size_t(i)].has_value())
+			if (slots[size_t(i)].id == ITEM_INVALID)
 				continue;
 			if (std::uniform_int_distribution<int>(0, weight++ - 1)(rng) == 0)
 				chosen = i;

--- a/src/bpp_shared/inventory/inventory.h
+++ b/src/bpp_shared/inventory/inventory.h
@@ -18,7 +18,7 @@ struct EntityPlayer;
 // Inventory
 struct Inventory {
 	std::string name = "Inventory";
-	std::vector<std::optional<ItemStack>> slots;
+	std::vector<ItemStack> slots;
 	bool isModified = false;
 
 	Inventory(size_t size) : slots(size) {}
@@ -36,18 +36,18 @@ struct Inventory {
 	virtual ItemStack* getStackInSlot(int slot) {
 		if (slot < 0 || slot >= (int)slots.size())
 			return nullptr;
-		if (!slots[size_t(slot)].has_value())
+		if (slots[size_t(slot)].id == ITEM_INVALID)
 			return nullptr;
-		return &slots[size_t(slot)].value();
+		return &slots[size_t(slot)];
 	}
 
 	virtual ItemStack decreaseStackSize(int slot, int count) {
-		if (slot < 0 || slot >= (int)slots.size() || !slots[size_t(slot)].has_value())
+		if (slot < 0 || slot >= (int)slots.size() || slots[size_t(slot)].id == ITEM_INVALID)
 			return ItemStack{};
-		auto& stack = slots[size_t(slot)].value();
+		auto& stack = slots[size_t(slot)];
 		if (stack.count <= count) {
 			ItemStack taken = stack;
-			slots[size_t(slot)] = std::nullopt;
+			slots[slot] = ItemStack{};
 			onInventoryChanged();
 			return taken;
 		}
@@ -60,7 +60,7 @@ struct Inventory {
 	virtual void setInventorySlotContents(int slot, ItemStack* stack) {
 		if (slot < 0 || slot >= (int)slots.size())
 			return;
-		slots[size_t(slot)] = stack ? std::optional<ItemStack>(*stack) : std::nullopt;
+		slots[size_t(slot)] = stack ? *stack : ItemStack{};
 		onInventoryChanged();
 	}
 
@@ -75,7 +75,7 @@ struct Inventory {
 	void clearSlot(int slot) {
 		if (slot < 0 || slot >= (int)slots.size())
 			return;
-		slots[size_t(slot)] = std::nullopt;
+		slots[size_t(slot)] = ItemStack{};
 		onInventoryChanged();
 	}
 
@@ -113,7 +113,7 @@ struct Inventory {
 
 		// We couldn't merge into existing items so just try and find an empty slot
 		for (int i = reverse ? end : start; reverse ? i >= start : i <= end; reverse ? i-- : i++) {
-			if (!slots[size_t(i)].has_value()) {
+			if (slots[size_t(i)].id == ITEM_INVALID) {
 				slots[size_t(i)] = ItemStack{ stack.id, stack.count, stack.data };
 				stack.id = ITEM_INVALID;
 				stack.data = 0;

--- a/src/bpp_shared/inventory/inventory_interaction.h
+++ b/src/bpp_shared/inventory/inventory_interaction.h
@@ -5,18 +5,20 @@
 */
 #pragma once
 #include "inventories.h"
+#include "inventory/item_stack.h"
+#include "items.h"
 #include "tile_entities/tile_entity.h"
 #include <memory>
 
-struct difference {
-	std::optional<ItemStack>& stack;
+struct DeltaSlot {
+	ItemStack stack;
 	int slot = 0;
 };
 
 // Used for actually interacting with inventories, will typically wrap 1 or more inventory objects for things like chests, etc
 struct InventoryInteraction {
-	std::vector<std::optional<ItemStack>> snapshot;
-	std::optional<ItemStack> carried;
+	std::vector<ItemStack> snapshot;
+	ItemStack carried;
 	Inventory* inventory;
 
 	InventoryInteraction(Inventory* inv) : inventory(inv) {}
@@ -33,8 +35,8 @@ struct InventoryInteraction {
 
 	// Analyze the snapshot vs the current inventory
 	// Returns a list of slots that are different
-	virtual std::vector<difference> tickDiff() {
-		std::vector<difference> differences;
+	virtual std::vector<DeltaSlot> tickDiff() {
+		std::vector<DeltaSlot> differences;
 		for (size_t i = 0; i < snapshot.size(); i++) {
 			[[maybe_unused]] auto* current = inventory->getStackInSlot(i);
 			auto& snap = snapshot[i];
@@ -54,16 +56,16 @@ struct InventoryInteraction {
 
 		// Empty slot
 		if (!targetSlot) {
-			if (carried.has_value()) {
-				inventory->setInventorySlotContents(slot, &carried.value());
-				carried = std::nullopt;
+			if (carried.id != ITEM_INVALID) {
+				inventory->setInventorySlotContents(slot, &carried);
+				carried = ItemStack{};
 			}
 			inventory->onInventoryChanged();
 			return;
 		}
 
 		// Not carrying anything
-		if (!carried.has_value()) {
+		if (carried.id == ITEM_INVALID) {
 			carried = *targetSlot;
 			inventory->clearSlot(slot);
 			inventory->onInventoryChanged();
@@ -71,21 +73,21 @@ struct InventoryInteraction {
 		}
 
 		// Same item; merge
-		if (targetSlot->id == carried->id && targetSlot->data == carried->data) {
+		if (targetSlot->id == carried.id && targetSlot->data == carried.data) {
 			int maxStack = GetMaxStack(targetSlot->id);
 			int space = maxStack - targetSlot->count;
-			int toMove = std::min(space, (int)carried->count);
+			int toMove = std::min(space, (int)carried.count);
 			targetSlot->count += toMove;
-			carried->count -= toMove;
-			if (carried->count == 0)
-				carried = std::nullopt;
+			carried.count -= toMove;
+			if (carried.count == 0)
+				carried = ItemStack{};
 			inventory->onInventoryChanged();
 			return;
 		}
 
 		// Different item; swap
 		ItemStack temp = *targetSlot;
-		*targetSlot = *carried;
+		*targetSlot = carried;
 		carried = temp;
 		inventory->onInventoryChanged();
 	}
@@ -93,26 +95,26 @@ struct InventoryInteraction {
 	virtual void onRightClick(int slot) {
 		auto targetSlot = inventory->getStackInSlot(slot);
 
-		if (carried.has_value()) {
+		if (carried.id != ITEM_INVALID) {
 			if (!targetSlot) {
-				ItemStack single{ carried->id, 1, carried->data };
+				ItemStack single{ carried.id, 1, carried.data };
 				inventory->setInventorySlotContents(slot, &single);
-				carried->count -= 1;
-				if (carried->count == 0)
-					carried = std::nullopt;
+				carried.count -= 1;
+				if (carried.count == 0)
+					carried = ItemStack{};
 				inventory->onInventoryChanged();
 				return;
 			}
 
 			// If we right click on the same item we are carrying just add one
-			if (targetSlot->id == carried->id && targetSlot->data == carried->data) {
+			if (targetSlot->id == carried.id && targetSlot->data == carried.data) {
 				int maxStack = GetMaxStack(targetSlot->id);
 				int space = maxStack - targetSlot->count;
 				if (space >= 1) {
 					targetSlot->count += 1;
-					carried->count -= 1;
-					if (carried->count == 0)
-						carried = std::nullopt;
+					carried.count -= 1;
+					if (carried.count == 0)
+						carried = ItemStack{};
 					inventory->onInventoryChanged();
 				}
 				return;
@@ -120,7 +122,7 @@ struct InventoryInteraction {
 
 			// If we right click on a different item, swap the cursor and that item
 			ItemStack temp = *targetSlot;
-			*targetSlot = *carried;
+			*targetSlot = carried;
 			carried = temp;
 			inventory->onInventoryChanged();
 			return;
@@ -192,21 +194,21 @@ struct LargeChestInventoryInteraction : InventoryInteraction {
 		snapshot.resize(size_t(chestInventory.getSizeInventory()));
 		for (size_t i = 0; i < size_t(chestInventory.getSizeInventory()); i++) {
 			auto* stack = chestInventory.getStackInSlot(i);
-			snapshot[i] = stack ? std::optional<ItemStack>(*stack) : std::nullopt;
+			snapshot[i] = stack ? *stack : ItemStack{};
 		}
 	}
 
 	// Analyze the snapshot vs the current chest inventory
-	std::vector<difference> tickDiff() override {
-		std::vector<difference> differences;
+	std::vector<DeltaSlot> tickDiff() override {
+		std::vector<DeltaSlot> differences;
 		for (size_t i = 0; i < snapshot.size(); i++) {
-			auto* current = chestInventory.getStackInSlot(int(i));
-			auto currentOpt = current ? std::optional<ItemStack>(*current) : std::nullopt;
+			auto* currentPtr = chestInventory.getStackInSlot(int(i));
+			auto current = currentPtr ? *currentPtr : ItemStack{};
 
-			if (snapshot[i] == currentOpt)
+			if (snapshot[i] == current)
 				continue;
 
-			snapshot[i] = currentOpt;
+			snapshot[i] = current;
 			differences.push_back({ snapshot[i], int(i) });
 		}
 		mergeInventories();
@@ -217,7 +219,7 @@ struct LargeChestInventoryInteraction : InventoryInteraction {
 		size_t slotCount = 0;
 		for (size_t i = 0; i < size_t(chestInventory.getSizeInventory()); i++) {
 			auto* stack = chestInventory.getStackInSlot(i);
-			sharedInventory.slots[slotCount++] = stack ? std::optional<ItemStack>(*stack) : std::nullopt;
+			sharedInventory.slots[slotCount++] = stack ? *stack : ItemStack{};
 		}
 		for (size_t i = 9; i <= 44; i++)
 			sharedInventory.slots[slotCount++] = playerInventory->slots[i];
@@ -226,7 +228,7 @@ struct LargeChestInventoryInteraction : InventoryInteraction {
 	void writeBack() {
 		for (size_t i = 0; i < 54; i++) {
 			auto& slot = sharedInventory.slots[i];
-			ItemStack* ptr = slot.has_value() ? &slot.value() : nullptr;
+			ItemStack* ptr = slot.id != ITEM_INVALID ? &slot : nullptr;
 			chestInventory.setInventorySlotContents(i, ptr);
 		}
 		for (size_t i = 54; i < 90; i++)
@@ -254,8 +256,7 @@ struct LargeChestInventoryInteraction : InventoryInteraction {
 			chestInventory.setInventorySlotContents(slot, ptr);
 		} else {
 			int playerSlot = slot - 54 + 9;
-			playerInventory->slots[size_t(playerSlot)] = copy.count == 0 ? std::nullopt
-			                                                             : std::optional<ItemStack>(copy);
+			playerInventory->slots[size_t(playerSlot)] = copy.count == 0 ? ItemStack{} : copy;
 		}
 
 		// Re-sync sharedInventory from the real inventories
@@ -301,8 +302,8 @@ struct ChestInventoryInteraction : InventoryInteraction {
 	}
 
 	// Analyze the snapshot vs the current chest inventory
-	std::vector<difference> tickDiff() override {
-		std::vector<difference> differences;
+	std::vector<DeltaSlot> tickDiff() override {
+		std::vector<DeltaSlot> differences;
 		for (size_t i = 0; i < snapshot.size(); i++) {
 			[[maybe_unused]] auto* current = chestInventory->getStackInSlot(i);
 			auto& snap = snapshot[i];
@@ -350,11 +351,10 @@ struct ChestInventoryInteraction : InventoryInteraction {
 
 		// Update the source in the real inventory before re-merging
 		if (slot <= 26) {
-			chestInventory->slots[size_t(slot)] = copy.count == 0 ? std::nullopt : std::optional<ItemStack>(copy);
+			chestInventory->slots[size_t(slot)] = copy.count == 0 ? ItemStack{} : copy;
 		} else {
 			int playerSlot = slot - 27 + 9;
-			playerInventory->slots[size_t(playerSlot)] = copy.count == 0 ? std::nullopt
-			                                                             : std::optional<ItemStack>(copy);
+			playerInventory->slots[size_t(playerSlot)] = copy.count == 0 ? ItemStack{} : copy;
 		}
 
 		// Re-sync sharedInventory from the real inventories

--- a/src/bpp_shared/tile_entities/tile_entity.cpp
+++ b/src/bpp_shared/tile_entities/tile_entity.cpp
@@ -5,6 +5,7 @@
  *
 */
 #include "tile_entity.h"
+#include "items.h"
 #include "world/chunk.h"
 
 void TileEntityChest::tick() {
@@ -58,11 +59,11 @@ Tag TileEntityChest::serialize() {
 	auto items = Tag{ .type = TAG_LIST, .name = "Items", .listType = TAG_COMPOUND };
 	int8_t currentSlot = 0;
 	for (auto& stack : inventory.slots) {
-		if (stack.has_value()) {
+		if (stack.id != ITEM_INVALID) {
 			auto item = Tag{ .type = TAG_COMPOUND };
-			auto Count = Tag{ .type = TAG_BYTE, .name = "Count", .byteValue = stack->count };
-			auto Damage = Tag{ .type = TAG_SHORT, .name = "Damage", .shortValue = stack->data };
-			auto Id = Tag{ .type = TAG_SHORT, .name = "id", .shortValue = stack->id };
+			auto Count = Tag{ .type = TAG_BYTE, .name = "Count", .byteValue = stack.count };
+			auto Damage = Tag{ .type = TAG_SHORT, .name = "Damage", .shortValue = stack.data };
+			auto Id = Tag{ .type = TAG_SHORT, .name = "id", .shortValue = stack.id };
 			auto Slot = Tag{ .type = TAG_BYTE, .name = "Slot", .byteValue = currentSlot };
 
 			item.compound["Count"] = Count;
@@ -97,11 +98,11 @@ Tag TileEntityFurnace::serialize() {
 	auto items = Tag{ .type = TAG_LIST, .name = "Items", .listType = TAG_COMPOUND };
 	int8_t currentSlot = 0;
 	for (auto& stack : inventory.slots) {
-		if (stack.has_value()) {
+		if (stack.id != ITEM_INVALID) {
 			auto item = Tag{ .type = TAG_COMPOUND };
-			auto Count = Tag{ .type = TAG_BYTE, .name = "Count", .byteValue = stack->count };
-			auto Damage = Tag{ .type = TAG_SHORT, .name = "Damage", .shortValue = stack->data };
-			auto Id = Tag{ .type = TAG_SHORT, .name = "id", .shortValue = stack->id };
+			auto Count = Tag{ .type = TAG_BYTE, .name = "Count", .byteValue = stack.count };
+			auto Damage = Tag{ .type = TAG_SHORT, .name = "Damage", .shortValue = stack.data };
+			auto Id = Tag{ .type = TAG_SHORT, .name = "id", .shortValue = stack.id };
 			auto Slot = Tag{ .type = TAG_BYTE, .name = "Slot", .byteValue = currentSlot };
 
 			item.compound["Count"] = Count;
@@ -136,11 +137,11 @@ Tag TileEntityDispenser::serialize() {
 	auto items = Tag{ .type = TAG_LIST, .name = "Items", .listType = TAG_COMPOUND };
 	int8_t currentSlot = 0;
 	for (auto& stack : inventory.slots) {
-		if (stack.has_value()) {
+		if (stack.id != ITEM_INVALID) {
 			auto item = Tag{ .type = TAG_COMPOUND };
-			auto Count = Tag{ .type = TAG_BYTE, .name = "Count", .byteValue = stack->count };
-			auto Damage = Tag{ .type = TAG_SHORT, .name = "Damage", .shortValue = stack->data };
-			auto Id = Tag{ .type = TAG_SHORT, .name = "id", .shortValue = stack->id };
+			auto Count = Tag{ .type = TAG_BYTE, .name = "Count", .byteValue = stack.count };
+			auto Damage = Tag{ .type = TAG_SHORT, .name = "Damage", .shortValue = stack.data };
+			auto Id = Tag{ .type = TAG_SHORT, .name = "id", .shortValue = stack.id };
 			auto Slot = Tag{ .type = TAG_BYTE, .name = "Slot", .byteValue = currentSlot };
 
 			item.compound["Count"] = Count;


### PR DESCRIPTION
std::optional is used to attach a hasValue metadata to types that don't have it, it uses 1 extra byte rathen than saving any memory.
The ID of the ItemStack can be checked against ITEM_INVALID instead.

Also implemented decreasing the held item stack when placing blocks.