### PR TITLE
Implement player inventory crafting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ set(SHARED_SOURCES
     src/bpp_shared/inventory/interactions/large_chest.cpp
     src/bpp_shared/inventory/interactions/crafting.cpp
     src/bpp_shared/inventory/interactions/player.cpp
+    src/bpp_shared/inventory/interactions/crafting_table.cpp
     src/bpp_shared/crafting/recipe_manager.cpp
     src/bpp_shared/crafting/vanilla_recipes.cpp
 

--- a/src/bpp_server/blocks/serverBlockBehaviors.cpp
+++ b/src/bpp_server/blocks/serverBlockBehaviors.cpp
@@ -6,16 +6,17 @@
 */
 #include "serverBlockBehaviors.h"
 #include "inventory/interactions/chest.h"
-#include "inventory/interactions/crafting.h"
+#include "inventory/interactions/crafting_table.h"
 #include "inventory/interactions/large_chest.h"
 
 namespace ServerBlock {
 BlockBehavior blockBehaviors[256] = {};
-}
+} // namespace ServerBlock
 
 void ServerBlock::initialize() {
 	// Register unique behaviors here
-	blockBehaviors[BLOCK_CRAFTING_TABLE].onBlockActivated = [](WorldManager& world, Int3 position, PlayerSession& session, Runtime& gameRuntime) -> bool {
+	blockBehaviors[BLOCK_CRAFTING_TABLE].onBlockActivated = [](WorldManager& world, Int3 position,
+	                                                           PlayerSession& session, Runtime& gameRuntime) -> bool {
 		Packet::OpenContainer ow;
 		ow.window_id = session.getNextWindowId();
 		ow.slot_count = 9;
@@ -23,11 +24,13 @@ void ServerBlock::initialize() {
 		ow.window_type = PacketData::WindowType::CRAFTING_TABLE;
 		ow.Serialize(session.stream);
 
-		session.activeInteraction = std::make_unique<CraftingInventoryInteraction>(&session.inventory, world, gameRuntime, position);
+		session.activeInteraction = std::make_unique<CraftingTableInventoryInteraction>(&session.inventory, world,
+		                                                                                gameRuntime, position);
 		session.activeInteraction->initSnapshot();
 		return false;
 	};
-	blockBehaviors[BLOCK_CHEST].onBlockActivated = [](WorldManager& world, Int3 position, PlayerSession& session, Runtime& gameRuntime) -> bool {
+	blockBehaviors[BLOCK_CHEST].onBlockActivated = [](WorldManager& world, Int3 position, PlayerSession& session,
+	                                                  Runtime& gameRuntime) -> bool {
 		auto chest = world.getTileEntityShared<TileEntityChest>(position);
 		if (!chest) {
 			chest = std::make_shared<TileEntityChest>(position);
@@ -66,7 +69,7 @@ void ServerBlock::initialize() {
 			ow.Serialize(session.stream);
 
 			session.activeInteraction = std::make_unique<LargeChestInventoryInteraction>(&session.inventory, chest,
-																						 partnerChest);
+			                                                                             partnerChest);
 			session.activeInteraction->initSnapshot();
 
 			PacketUtilities::sendInventory(session, session.openWindowId, *session.activeInteraction->inventory);

--- a/src/bpp_server/entities/entity_mp_player.cpp
+++ b/src/bpp_server/entities/entity_mp_player.cpp
@@ -5,8 +5,10 @@
  *
 */
 #include "entity_mp_player.h"
-#include "entities/entity_item.h"
 #include "../player_conn/player_session.h"
+#include "entities/entity_item.h"
+#include "entities/entity_player.h"
+#include "inventory/item_stack.h"
 #include "networking/network_stream.h"
 #include "networking/packets.h"
 
@@ -19,43 +21,27 @@ bool EntityMPPlayer::pickupItem(ItemStack& stack, EntityId entityId) {
 		pkt.Serialize(this->session->stream);
 		return true;
 	}
+
+	return false;
 }
 
-bool EntityMPPlayer::dropHeldItem(int count) {
-	auto itemStack = this->session->inventory.getHeldItem();
-	if (!itemStack) return false;
-	if (itemStack->id == ITEM_INVALID || itemStack->count <= 0) return false;
-
-	int difference = itemStack->count - count;
-	int newSize = std::max(0, difference);
-	int droppedSize = count;
-	if (difference < 0) droppedSize -= difference;
-
-	itemStack->count = newSize;
-
-	// Create our new item stack
-	ItemStack newStack;
-	newStack.count = droppedSize;
-	newStack.data = itemStack->data;
-	newStack.id = itemStack->id;
+// This works over a copy of your item, it doesn't remove or decrement it !!!
+bool EntityMPPlayer::dropItem(ItemStack stack) {
+	if (stack.id == ITEM_INVALID || stack.count <= 0)
+		return false;
 
 	// Create the item entity
 	Vec3 position = { posX, posY - 0.3 + PLAYER_EYE_HEIGHT, posZ };
 	std::shared_ptr<ItemEntity> itemEntity = std::make_shared<ItemEntity>(position);
-	itemEntity->itemStack = std::move(newStack);
+	itemEntity->itemStack = stack;
 	itemEntity->pickupCooldown = 40; // So we don't pick it up instantly
-
-	// If we exhausted all our held item then clear it
-	if (itemStack->count <= 0) {
-		itemStack->id = ITEM_INVALID;
-		itemStack->count = 0;
-		itemStack->data = 0;
-	}
 
 	// Give ourselves some random velocity based on look direction
 	float velocity = 0.4f;
-	itemEntity->motionX = double(-std::sin(this->rotationYaw   / 180.0F * JavaMath::PI_FLOAT) * std::cos(this->rotationPitch / 180.0F * JavaMath::PI_FLOAT) * velocity);
-	itemEntity->motionZ = double( std::cos(this->rotationYaw   / 180.0F * JavaMath::PI_FLOAT) * std::cos(this->rotationPitch / 180.0F * JavaMath::PI_FLOAT) * velocity);
+	itemEntity->motionX = double(-std::sin(this->rotationYaw / 180.0F * JavaMath::PI_FLOAT) *
+	                             std::cos(this->rotationPitch / 180.0F * JavaMath::PI_FLOAT) * velocity);
+	itemEntity->motionZ = double(std::cos(this->rotationYaw / 180.0F * JavaMath::PI_FLOAT) *
+	                             std::cos(this->rotationPitch / 180.0F * JavaMath::PI_FLOAT) * velocity);
 	itemEntity->motionY = double(-std::sin(this->rotationPitch / 180.0F * JavaMath::PI_FLOAT) * velocity + 0.1F);
 
 	// Add a little bit of randomness

--- a/src/bpp_server/entities/entity_mp_player.h
+++ b/src/bpp_server/entities/entity_mp_player.h
@@ -7,6 +7,7 @@
 #pragma once
 #include "entities.h"
 #include "entities/entity_player.h"
+#include "inventory/item_stack.h"
 
 struct PlayerSession;
 struct EntityMPPlayer : public PlayerEntity {
@@ -17,5 +18,5 @@ struct EntityMPPlayer : public PlayerEntity {
 	}
 	void tick() override;
 	bool pickupItem(ItemStack& stack, EntityId entityId) override;
-	bool dropHeldItem(int count);
+	bool dropItem(ItemStack stack) override;
 };

--- a/src/bpp_server/packet/handle_packet.cpp
+++ b/src/bpp_server/packet/handle_packet.cpp
@@ -6,9 +6,9 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  *
 */
-#include "../entities/entity_tracker.h"
-#include "../blocks/serverBlockBehaviors.h"
 #include "handle_packet.h"
+#include "../blocks/serverBlockBehaviors.h"
+#include "../entities/entity_tracker.h"
 #include "blocks.h"
 #include "entities/entity_item.h"
 #include "inventory/inventory_interaction.h"
@@ -58,7 +58,7 @@ void PlayerPositionAndRotation(Packet::PlayerPositionAndRotation& pkt, PlayerSes
 
 void MineBlock(Packet::MineBlock& pkt, PlayerSession& session, WorldManager& world,
                std::vector<std::shared_ptr<PlayerSession>>& /*players*/) {
-	Int3 packetPos = {pkt.position.x, pkt.position.y, pkt.position.z};
+	Int3 packetPos = { pkt.position.x, pkt.position.y, pkt.position.z };
 	switch (pkt.status) {
 	case PacketData::MineStatus::DIGGING_STARTED: {
 		session.startedMiningAtTick = world.elapsed_ticks;
@@ -95,8 +95,15 @@ void MineBlock(Packet::MineBlock& pkt, PlayerSession& session, WorldManager& wor
 		return;
 	}
 	case PacketData::MineStatus::DROPPED_ITEM: {
-		int count = 1;
-		session.entity->dropHeldItem(count);
+		ItemStack* heldStack = session.inventory.getHeldItem();
+		if (!heldStack)
+			return;
+
+		ItemStack droppedStack = *heldStack;
+		droppedStack.count = 1;
+
+		if (session.entity->dropItem(droppedStack))
+			heldStack->decrementCount(1);
 		return;
 	}
 	default:
@@ -113,8 +120,8 @@ void PlaceBlock(Packet::PlaceBlock& pkt, PlayerSession& session, WorldManager& w
 	// Function returns true if we can place a block after running the function
 	if (ServerBlock::blockBehaviors[block].onBlockActivated) {
 		if (!ServerBlock::blockBehaviors[block].onBlockActivated(world, position, session, gameRuntime))
-			return; 
-	} 
+			return;
+	}
 	// The server didn't override our block's behavior so check the base behavior
 	else if (Blocks::blockBehaviors[block].onBlockActivated) {
 		if (!Blocks::blockBehaviors[block].onBlockActivated(world, position))
@@ -231,7 +238,16 @@ void ClickSlot(Packet::ClickSlot& pkt, PlayerSession& session) {
 	return;
 }
 
-void CloseContainer(Packet::CloseContainer& /*pkt*/, PlayerSession& session) {
+void CloseContainer(Packet::CloseContainer& pkt, PlayerSession& session) {
+	if (pkt.window_id == 0 && session.entity) {
+		// Drop the crafting grid items on inventory close
+		for (size_t i = 1; i <= 4; i++) {
+			ItemStack& stack = session.inventory.slots[i];
+			session.entity->dropItem(session.inventory.slots[i]);
+			stack = ItemStack{};
+		}
+	}
+
 	// Get rid of our active interaction and reset the window id
 	session.activeInteraction = nullptr;
 	session.openWindowId = 0;

--- a/src/bpp_server/player_conn/player_session.h
+++ b/src/bpp_server/player_conn/player_session.h
@@ -80,7 +80,8 @@ struct PlayerSession {
 	BlockType lastTargetedBlock = BLOCK_AIR;
 	TickTime startedMiningAtTick = 0;
 
-	explicit PlayerSession(int socket) : stream(socket), inventoryInteraction(&inventory) {}
+	explicit PlayerSession(int socket, Runtime& gameRuntime)
+	    : stream(socket), inventoryInteraction(&inventory, gameRuntime) {}
 	~PlayerSession() {
 		// So our player entity despawns from the world
 		if (entity) {

--- a/src/bpp_server/server.cpp
+++ b/src/bpp_server/server.cpp
@@ -310,7 +310,7 @@ void Server::acceptNewPlayers() {
 	auto clientSocket = ServerSocketManager::createClientSocket(serverSocket);
 	if (clientSocket < 0)
 		return;
-	players.push_back(std::make_shared<PlayerSession>(clientSocket));
+	players.push_back(std::make_shared<PlayerSession>(clientSocket, gameRuntime));
 }
 
 void Server::tick() {

--- a/src/bpp_shared/crafting/recipe_manager.cpp
+++ b/src/bpp_shared/crafting/recipe_manager.cpp
@@ -8,6 +8,7 @@
 #include "recipe_manager.h"
 #include "inventory/item_stack.h"
 #include "logger.h"
+#include "numeric_structs.h"
 #include <algorithm>
 
 void RecipeManager::addShapelessRecipe(std::span<const ItemKey> items, ItemStack output) {
@@ -65,7 +66,7 @@ void RecipeManager::addShapedRecipe(std::initializer_list<std::string_view> rows
 		++y;
 	}
 
-	auto [it, inserted] = shapedRecipes.try_emplace(makeShapedKey(grid, 3, 3), output);
+	auto [it, inserted] = shapedRecipes.try_emplace(makeShapedKey(grid, {3, 3}), output);
 
 	if (!inserted) {
 		it->second = output;
@@ -73,20 +74,20 @@ void RecipeManager::addShapedRecipe(std::initializer_list<std::string_view> rows
 	}
 }
 
-const ItemStack RecipeManager::matchGrid(std::span<const ItemStack> grid, uint8_t width, uint8_t height) const {
+const ItemStack RecipeManager::matchGrid(std::span<const ItemStack> grid, UInt8_2 size) const {
 	std::array<ItemKey, 9> keyGrid{};
 
-	const size_t size = static_cast<size_t>(width) * height;
+	const size_t total_size = size_t(size.total());
 
-	for (size_t i = 0; i < size; ++i)
+	for (size_t i = 0; i < total_size; ++i)
 		keyGrid[i] = { grid[i].id, grid[i].data };
 
-	auto shaped = shapedRecipes.find(makeShapedKey(std::span<const ItemKey>(keyGrid.data(), size), width, height));
+	auto shaped = shapedRecipes.find(makeShapedKey(std::span<const ItemKey>(keyGrid.data(), total_size), size));
 
 	if (shaped != shapedRecipes.end())
 		return shaped->second;
 
-	auto shapeless = shapelessRecipes.find(makeShapelessKey(std::span<const ItemKey>(keyGrid.data(), size)));
+	auto shapeless = shapelessRecipes.find(makeShapelessKey(std::span<const ItemKey>(keyGrid.data(), total_size)));
 
 	if (shapeless != shapelessRecipes.end())
 		return shapeless->second;
@@ -94,16 +95,16 @@ const ItemStack RecipeManager::matchGrid(std::span<const ItemStack> grid, uint8_
 	return { .id = ITEM_INVALID };
 }
 
-ShapedRecipeKey RecipeManager::makeShapedKey(std::span<const ItemKey> grid, uint8_t width, uint8_t height) {
+ShapedRecipeKey RecipeManager::makeShapedKey(std::span<const ItemKey> grid, UInt8_2 size) {
 	int minX = 3;
 	int minY = 3;
 	int maxX = -1;
 	int maxY = -1;
 
 	// Find the bounding box of the recipe
-	for (int y = 0; y < height; ++y) {
-		for (int x = 0; x < width; ++x) {
-			const auto& item = grid[y * width + x];
+	for (int y = 0; y < size.y; ++y) {
+		for (int x = 0; x < size.x; ++x) {
+			const auto& item = grid[y * size.x + x];
 
 			if (item.id == ITEM_INVALID)
 				continue;
@@ -127,7 +128,7 @@ ShapedRecipeKey RecipeManager::makeShapedKey(std::span<const ItemKey> grid, uint
 	// Copy the actual recipe to top left
 	for (int y = 0; y < key.height; ++y) {
 		for (int x = 0; x < key.width; ++x) {
-			key.cells[y * 3 + x] = grid[(minY + y) * width + (minX + x)];
+			key.cells[y * 3 + x] = grid[(minY + y) * size.x + (minX + x)];
 		}
 	}
 

--- a/src/bpp_shared/crafting/recipe_manager.cpp
+++ b/src/bpp_shared/crafting/recipe_manager.cpp
@@ -65,7 +65,7 @@ void RecipeManager::addShapedRecipe(std::initializer_list<std::string_view> rows
 		++y;
 	}
 
-	auto [it, inserted] = shapedRecipes.try_emplace(makeShapedKey(grid), output);
+	auto [it, inserted] = shapedRecipes.try_emplace(makeShapedKey(grid, 3, 3), output);
 
 	if (!inserted) {
 		it->second = output;
@@ -73,40 +73,39 @@ void RecipeManager::addShapedRecipe(std::initializer_list<std::string_view> rows
 	}
 }
 
-const ItemStack RecipeManager::matchGrid(std::span<const ItemStack, 9> grid) const {
-	std::array<ItemKey, 9> keyGrid;
-	for (size_t i = 0; i < grid.size(); ++i) {
-		const ItemStack& stack = grid[i];
-		keyGrid[i] = ItemKey{ stack.id, stack.data };
-	}
+const ItemStack RecipeManager::matchGrid(std::span<const ItemStack> grid, uint8_t width, uint8_t height) const {
+	std::array<ItemKey, 9> keyGrid{};
 
-	{
-		auto it = shapedRecipes.find(makeShapedKey(keyGrid));
-		if (it != shapedRecipes.end())
-			return it->second;
-	}
+	const size_t size = static_cast<size_t>(width) * height;
 
-	{
-		auto it = shapelessRecipes.find(makeShapelessKey(keyGrid));
-		if (it != shapelessRecipes.end())
-			return it->second;
-	}
+	for (size_t i = 0; i < size; ++i)
+		keyGrid[i] = { grid[i].id, grid[i].data };
 
-	return ItemStack{ .id = ITEM_INVALID };
+	auto shaped = shapedRecipes.find(makeShapedKey(std::span<const ItemKey>(keyGrid.data(), size), width, height));
+
+	if (shaped != shapedRecipes.end())
+		return shaped->second;
+
+	auto shapeless = shapelessRecipes.find(makeShapelessKey(std::span<const ItemKey>(keyGrid.data(), size)));
+
+	if (shapeless != shapelessRecipes.end())
+		return shapeless->second;
+
+	return { .id = ITEM_INVALID };
 }
 
-ShapedRecipeKey RecipeManager::makeShapedKey(std::span<const ItemKey, 9> grid) {
+ShapedRecipeKey RecipeManager::makeShapedKey(std::span<const ItemKey> grid, uint8_t width, uint8_t height) {
 	int minX = 3;
 	int minY = 3;
 	int maxX = -1;
 	int maxY = -1;
 
 	// Find the bounding box of the recipe
-	for (int y = 0; y < 3; ++y) {
-		for (int x = 0; x < 3; ++x) {
-			const auto& item = grid[y * 3 + x];
+	for (int y = 0; y < height; ++y) {
+		for (int x = 0; x < width; ++x) {
+			const auto& item = grid[y * width + x];
 
-			if (item.id == ITEM_INVALID || item.id == ITEM_NONE)
+			if (item.id == ITEM_INVALID)
 				continue;
 
 			minX = std::min(minX, x);
@@ -128,7 +127,7 @@ ShapedRecipeKey RecipeManager::makeShapedKey(std::span<const ItemKey, 9> grid) {
 	// Copy the actual recipe to top left
 	for (int y = 0; y < key.height; ++y) {
 		for (int x = 0; x < key.width; ++x) {
-			key.cells[y * 3 + x] = grid[(minY + y) * 3 + (minX + x)];
+			key.cells[y * 3 + x] = grid[(minY + y) * width + (minX + x)];
 		}
 	}
 

--- a/src/bpp_shared/crafting/recipe_manager.h
+++ b/src/bpp_shared/crafting/recipe_manager.h
@@ -9,6 +9,7 @@
 
 #include "hash.h"
 #include "inventory/item_stack.h"
+#include "numeric_structs.h"
 
 #include <array>
 #include <span>
@@ -84,10 +85,10 @@ public:
 
 	void addVanillaRecipes();
 
-	[[nodiscard]] const ItemStack matchGrid(std::span<const ItemStack> grid, uint8_t width, uint8_t height) const;
+	[[nodiscard]] const ItemStack matchGrid(std::span<const ItemStack> grid, UInt8_2 size) const;
 
 private:
-	static ShapedRecipeKey makeShapedKey(std::span<const ItemKey> grid, uint8_t width, uint8_t height);
+	static ShapedRecipeKey makeShapedKey(std::span<const ItemKey> grid, UInt8_2 size);
 	static ShapelessRecipeKey makeShapelessKey(std::span<const ItemKey> items);
 
 	std::unordered_map<ShapedRecipeKey, ItemStack, ShapedRecipeKeyHasher> shapedRecipes;

--- a/src/bpp_shared/crafting/recipe_manager.h
+++ b/src/bpp_shared/crafting/recipe_manager.h
@@ -84,10 +84,10 @@ public:
 
 	void addVanillaRecipes();
 
-	[[nodiscard]] const ItemStack matchGrid(std::span<const ItemStack, 9> grid) const;
+	[[nodiscard]] const ItemStack matchGrid(std::span<const ItemStack> grid, uint8_t width, uint8_t height) const;
 
 private:
-	static ShapedRecipeKey makeShapedKey(std::span<const ItemKey, 9> grid);
+	static ShapedRecipeKey makeShapedKey(std::span<const ItemKey> grid, uint8_t width, uint8_t height);
 	static ShapelessRecipeKey makeShapelessKey(std::span<const ItemKey> items);
 
 	std::unordered_map<ShapedRecipeKey, ItemStack, ShapedRecipeKeyHasher> shapedRecipes;

--- a/src/bpp_shared/entities/entity_player.cpp
+++ b/src/bpp_shared/entities/entity_player.cpp
@@ -9,3 +9,7 @@
 bool PlayerEntity::pickupItem(ItemStack& stack, EntityId entityId) {
 	return true;
 }
+
+bool PlayerEntity::dropItem(ItemStack stack) {
+	return true;
+}

--- a/src/bpp_shared/entities/entity_player.h
+++ b/src/bpp_shared/entities/entity_player.h
@@ -18,4 +18,5 @@ struct PlayerEntity : public Entity {
 	}
 	~PlayerEntity() = default;
 	virtual bool pickupItem(ItemStack& stack, EntityId entityId);
+	virtual bool dropItem(ItemStack stack);
 };

--- a/src/bpp_shared/inventory/interactions/crafting.cpp
+++ b/src/bpp_shared/inventory/interactions/crafting.cpp
@@ -4,98 +4,33 @@
  * SPDX-License-Identifier: AGPL-3.0-only
 */
 #include "crafting.h"
-#include "blocks.h"
-#include "inventory/item_stack.h"
-#include "items.h"
+#include "inventory/inventory_interaction.h"
 
-CraftingInventoryInteraction::CraftingInventoryInteraction(InventoryPlayer* pinv, WorldManager& worldMng,
-                                                           Runtime& gameRuntime, Int3 craftingTablePos)
-    : InventoryInteraction(&sharedInventory), playerInventory(pinv), world(worldMng), runtime(gameRuntime),
-      blockPosition(craftingTablePos) {
-	sharedInventory.owner = this;
-	mergeInventories();
-}
-
-CraftingInventoryInteraction::~CraftingInventoryInteraction() {
-	writeBack();
-
-	// Return the crafting grid back to the player
-	for (size_t i = 1; i < 10; i++) {
-		ItemStack& stack = craftInventory.slots[i];
-		if (stack.id == ITEM_INVALID)
-			continue;
-		playerInventory->mergeItemStackInInventory(stack, true, 9, 44);
-	}
-}
-
-bool CraftingInventoryInteraction::canExist() {
-	return world.getBlockId(blockPosition) == BLOCK_CRAFTING_TABLE;
-}
-
-void CraftingInventoryInteraction::initSnapshot() {
-	snapshot.resize(size_t(sharedInventory.getSizeInventory()));
-	for (size_t i = 0; i < snapshot.size(); i++)
-		snapshot[i] = sharedInventory.slots[i];
-}
-
-std::vector<DeltaSlot> CraftingInventoryInteraction::tickDiff() {
-	std::vector<DeltaSlot> differences;
-	mergeInventories(); // make sure sharedInventory is current before diffing
-	for (size_t i = 0; i < snapshot.size(); i++) {
-		auto& snap = snapshot[i];
-		if (snap == sharedInventory.slots[i])
-			continue;
-		snap = sharedInventory.slots[i];
-		differences.push_back({ snap, int(i) });
-	}
-	return differences;
-}
-
-void CraftingInventoryInteraction::mergeInventories() {
-	size_t slotCount = 0;
-	for (size_t i = 0; i < 10; i++)
-		sharedInventory.slots[slotCount++] = craftInventory.slots[i];
-	for (size_t i = 9; i < 45; i++)
-		sharedInventory.slots[slotCount++] = playerInventory->slots[i];
-}
-
-void CraftingInventoryInteraction::writeBack() {
-	size_t slotCount = 0;
-	for (size_t i = 0; i < 10; i++)
-		craftInventory.slots[i] = sharedInventory.slots[slotCount++];
-	for (size_t i = 9; i < 45; i++)
-		playerInventory->slots[i] = sharedInventory.slots[slotCount++];
-}
+CraftingInventoryInteraction::CraftingInventoryInteraction(Inventory* sharedInventory, Inventory* craftingInventory,
+                                                           InventoryPlayer* playerInventory, Runtime& gameRuntime,
+                                                           uint8_t width, uint8_t height)
+    : InventoryInteraction(sharedInventory), craftInventory(craftingInventory), playerInventory(playerInventory),
+      runtime(gameRuntime), gridWidth(width), gridHeight(height) {}
 
 void CraftingInventoryInteraction::updateResult() {
-	auto grid = std::span<const ItemStack, 9>(craftInventory.slots.data() + 1, 9);
-	ItemStack result = runtime.recipeManager.matchGrid(grid);
-	lastResult = result;
-	craftInventory.slots[0] = result;
-}
-
-void CraftingInventoryInteraction::handleCrafting(int slot) {
-	if (slot == 0 || slot > 9)
-		return;
-
-	// Grid changed (either by player or decrementCount)
-	updateResult();
+	auto grid = std::span<const ItemStack>(craftInventory->slots.data() + 1, gridWidth * gridHeight);
+	ItemStack result = runtime.recipeManager.matchGrid(grid, gridWidth, gridHeight);
+	craftInventory->slots[0] = result;
 }
 
 void CraftingInventoryInteraction::finishCraft() {
-	craftInventory.slots[0] = ItemStack{};
+	craftInventory->slots[0] = ItemStack{};
 
 	// Consume one of each ingredient that went into this craft
-	for (size_t i = 1; i < 10; ++i)
-		craftInventory.slots[i].decrementCount(1);
+	for (size_t i = 1; i <= gridWidth * gridHeight; ++i)
+		craftInventory->slots[i].decrementCount(1);
 
 	// The grid changed, there might be another possible craft
 	updateResult();
-	mergeInventories();
 }
 
 void CraftingInventoryInteraction::takeResult() {
-	ItemStack& result = craftInventory.slots[0];
+	ItemStack& result = craftInventory->slots[0];
 	if (result.id == ITEM_INVALID)
 		return;
 
@@ -115,6 +50,13 @@ void CraftingInventoryInteraction::takeResult() {
 	finishCraft();
 }
 
+void CraftingInventoryInteraction::handleCrafting(int slot) {
+	if (slot == 0 || slot > gridWidth * gridHeight)
+		return;
+
+	updateResult();
+}
+
 void CraftingInventoryInteraction::onLeftClick(int slot) {
 	if (slot == 0)
 		takeResult();
@@ -131,59 +73,10 @@ void CraftingInventoryInteraction::onRightClick(int slot) {
 	handleCrafting(slot);
 }
 
-void CraftingInventoryInteraction::shiftClickResult() {
-	ItemStack& result = craftInventory.slots[0];
-	if (result.id == ITEM_INVALID)
-		return;
-
-	ItemStack copy = result;
-	if (playerInventory->mergeItemStackInInventory(copy, true, 9, 44)) {
-		finishCraft();
-	} else {
-		craftInventory.slots[0] = copy.count == 0 ? ItemStack{} : copy;
-	}
-
-	mergeInventories();
-}
-
 void CraftingInventoryInteraction::onShiftClick(int slot) {
 	if (slot == 0)
 		shiftClickResult();
 	else
-		shiftClickGrid(slot);
+		shiftClickOther(slot);
 	handleCrafting(slot);
-}
-
-void CraftingInventoryInteraction::shiftClickGrid(int slot) {
-	auto stack = sharedInventory.getStackInSlot(slot);
-	if (!stack)
-		return;
-
-	ItemStack copy = *stack;
-
-	if (slot < 10) {
-		// Grid -> inventory
-		// Try the main inventory then the hotbar
-		bool success = playerInventory->mergeItemStackInInventory(copy, false, 9, 35);
-		if (!success)
-			playerInventory->mergeItemStackInInventory(copy, false, 36, 44);
-	} else {
-		// We can't shift click into the crafting grid itself, so just try the other area of the inventory
-		// We shift clicked in the inventory
-		if (slot > 9 && slot < 37) {
-			playerInventory->mergeItemStackInInventory(copy, false, 36, 44);
-		} else {
-			playerInventory->mergeItemStackInInventory(copy, false, 9, 35);
-		}
-	}
-
-	// Update the source in the real inventory before re-merging
-	if (slot < 10) {
-		craftInventory.slots[slot] = copy.count == 0 ? ItemStack{} : copy;
-	} else {
-		playerInventory->slots[slot - 1] = copy.count == 0 ? ItemStack{} : copy;
-	}
-
-	// Re-sync sharedInventory from the real inventories
-	mergeInventories();
 }

--- a/src/bpp_shared/inventory/interactions/crafting.cpp
+++ b/src/bpp_shared/inventory/interactions/crafting.cpp
@@ -5,16 +5,17 @@
 */
 #include "crafting.h"
 #include "inventory/inventory_interaction.h"
+#include "numeric_structs.h"
 
 CraftingInventoryInteraction::CraftingInventoryInteraction(Inventory* sharedInventory, Inventory* craftingInventory,
                                                            InventoryPlayer* playerInventory, Runtime& gameRuntime,
-                                                           uint8_t width, uint8_t height)
+                                                           UInt8_2 gridSize)
     : InventoryInteraction(sharedInventory), craftInventory(craftingInventory), playerInventory(playerInventory),
-      runtime(gameRuntime), gridWidth(width), gridHeight(height) {}
+      runtime(gameRuntime), m_gridSize(gridSize) {}
 
 void CraftingInventoryInteraction::updateResult() {
-	auto grid = std::span<const ItemStack>(craftInventory->slots.data() + 1, gridWidth * gridHeight);
-	ItemStack result = runtime.recipeManager.matchGrid(grid, gridWidth, gridHeight);
+	auto grid = std::span<const ItemStack>(craftInventory->slots.data() + 1, m_gridSize.total());
+	ItemStack result = runtime.recipeManager.matchGrid(grid, m_gridSize);
 	craftInventory->slots[0] = result;
 }
 
@@ -22,7 +23,7 @@ void CraftingInventoryInteraction::finishCraft() {
 	craftInventory->slots[0] = ItemStack{};
 
 	// Consume one of each ingredient that went into this craft
-	for (size_t i = 1; i <= gridWidth * gridHeight; ++i)
+	for (size_t i = 1; i <= m_gridSize.total(); ++i)
 		craftInventory->slots[i].decrementCount(1);
 
 	// The grid changed, there might be another possible craft
@@ -51,7 +52,7 @@ void CraftingInventoryInteraction::takeResult() {
 }
 
 void CraftingInventoryInteraction::handleCrafting(int slot) {
-	if (slot == 0 || slot > gridWidth * gridHeight)
+	if (slot == 0 || slot > m_gridSize.total())
 		return;
 
 	updateResult();

--- a/src/bpp_shared/inventory/interactions/crafting.h
+++ b/src/bpp_shared/inventory/interactions/crafting.h
@@ -20,15 +20,14 @@ public:
 	// We don't do any inventory merging in this class because
 	// sharedInventory, craftingInventory, playerInventory all may or may not be the same thing.
 	CraftingInventoryInteraction(Inventory* sharedInventory, Inventory* craftingInventory,
-	                             InventoryPlayer* playerInventory, Runtime& gameRuntime, uint8_t width, uint8_t height);
+	                             InventoryPlayer* playerInventory, Runtime& gameRuntime, UInt8_2 gridSize);
 
 	void onLeftClick(int slot) override;
 	void onRightClick(int slot) override;
 	void onShiftClick(int slot) override;
 
 protected:
-	const uint8_t gridWidth;
-	const uint8_t gridHeight;
+	const UInt8_2 m_gridSize;
 
 	void handleCrafting(int slot);
 	void finishCraft();

--- a/src/bpp_shared/inventory/interactions/crafting.h
+++ b/src/bpp_shared/inventory/interactions/crafting.h
@@ -6,45 +6,35 @@
 #pragma once
 #include "../inventory_interaction.h"
 #include "inventory/inventories.h"
+#include "inventory/inventory.h"
 #include "runtime.h"
-#include "world.h"
 
 struct CraftingInventoryInteraction : InventoryInteraction {
+private:
+	Inventory* craftInventory;
+
+public:
 	InventoryPlayer* playerInventory;
-	InventoryCrafting craftInventory;
-	WorldManager& world;
 	Runtime& runtime;
-	Int3 blockPosition;
-	ItemStack lastResult;
 
-	struct SharedInventory : Inventory {
-		CraftingInventoryInteraction* owner = nullptr;
-		SharedInventory() : Inventory(46) {}
-		void onInventoryChanged() override {
-			if (owner)
-				owner->writeBack();
-		}
-	} sharedInventory;
+	// We don't do any inventory merging in this class because
+	// sharedInventory, craftingInventory, playerInventory all may or may not be the same thing.
+	CraftingInventoryInteraction(Inventory* sharedInventory, Inventory* craftingInventory,
+	                             InventoryPlayer* playerInventory, Runtime& gameRuntime, uint8_t width, uint8_t height);
 
-	CraftingInventoryInteraction(InventoryPlayer* pinv, WorldManager& worldMng, Runtime& gameRuntime,
-	                             Int3 craftingTablePos);
-
-	virtual ~CraftingInventoryInteraction();
-
-	bool canExist() override;
-	void initSnapshot() override;
-	std::vector<DeltaSlot> tickDiff() override;
 	void onLeftClick(int slot) override;
 	void onRightClick(int slot) override;
 	void onShiftClick(int slot) override;
 
-private:
-	void mergeInventories();
-	void writeBack();
-	void updateResult();
+protected:
+	const uint8_t gridWidth;
+	const uint8_t gridHeight;
+
 	void handleCrafting(int slot);
 	void finishCraft();
 	void takeResult();
-	void shiftClickResult();
-	void shiftClickGrid(int slot);
+
+	virtual void updateResult();
+	virtual void shiftClickResult() = 0;
+	virtual void shiftClickOther(int slot) = 0;
 };

--- a/src/bpp_shared/inventory/interactions/crafting_table.cpp
+++ b/src/bpp_shared/inventory/interactions/crafting_table.cpp
@@ -11,7 +11,7 @@
 
 CraftingTableInventoryInteraction::CraftingTableInventoryInteraction(InventoryPlayer* pinv, WorldManager& worldMng,
                                                                      Runtime& gameRuntime, Int3 craftingTablePos)
-    : CraftingInventoryInteraction(&sharedInventory, &craftInventory, pinv, gameRuntime, 3, 3), world(worldMng),
+    : CraftingInventoryInteraction(&sharedInventory, &craftInventory, pinv, gameRuntime, {3, 3}), world(worldMng),
       blockPosition(craftingTablePos) {
 	sharedInventory.owner = this;
 	mergeInventories();
@@ -20,7 +20,7 @@ CraftingTableInventoryInteraction::CraftingTableInventoryInteraction(InventoryPl
 CraftingTableInventoryInteraction::~CraftingTableInventoryInteraction() {
 	writeBack();
 
-	for (size_t i = 1; i <= gridWidth * gridHeight; i++) {
+	for (size_t i = 1; i <= m_gridSize.total(); i++) {
 		ItemStack& stack = craftInventory.slots[i];
 		if (stack.id == ITEM_INVALID)
 			continue;

--- a/src/bpp_shared/inventory/interactions/crafting_table.cpp
+++ b/src/bpp_shared/inventory/interactions/crafting_table.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026, jwaxy <jwaxy.is-a.dev>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+*/
+#include "crafting_table.h"
+#include "blocks.h"
+#include "inventory/interactions/crafting.h"
+#include "inventory/item_stack.h"
+#include "items.h"
+
+CraftingTableInventoryInteraction::CraftingTableInventoryInteraction(InventoryPlayer* pinv, WorldManager& worldMng,
+                                                                     Runtime& gameRuntime, Int3 craftingTablePos)
+    : CraftingInventoryInteraction(&sharedInventory, &craftInventory, pinv, gameRuntime, 3, 3), world(worldMng),
+      blockPosition(craftingTablePos) {
+	sharedInventory.owner = this;
+	mergeInventories();
+}
+
+CraftingTableInventoryInteraction::~CraftingTableInventoryInteraction() {
+	writeBack();
+
+	for (size_t i = 1; i <= gridWidth * gridHeight; i++) {
+		ItemStack& stack = craftInventory.slots[i];
+		if (stack.id == ITEM_INVALID)
+			continue;
+		playerInventory->mergeItemStackInInventory(stack, true, 9, 44);
+	}
+}
+
+void CraftingTableInventoryInteraction::writeBack() {
+	size_t slotCount = 0;
+	for (size_t i = 0; i < 10; i++)
+		craftInventory.slots[i] = sharedInventory.slots[slotCount++];
+	for (size_t i = 9; i < 45; i++)
+		playerInventory->slots[i] = sharedInventory.slots[slotCount++];
+}
+
+bool CraftingTableInventoryInteraction::canExist() {
+	return world.getBlockId(blockPosition) == BLOCK_CRAFTING_TABLE;
+}
+
+void CraftingTableInventoryInteraction::initSnapshot() {
+	snapshot.resize(size_t(sharedInventory.getSizeInventory()));
+	for (size_t i = 0; i < snapshot.size(); i++)
+		snapshot[i] = sharedInventory.slots[i];
+}
+
+std::vector<DeltaSlot> CraftingTableInventoryInteraction::tickDiff() {
+	std::vector<DeltaSlot> differences;
+	mergeInventories(); // make sure sharedInventory is current before diffing
+	for (size_t i = 0; i < snapshot.size(); i++) {
+		auto& snap = snapshot[i];
+		if (snap == sharedInventory.slots[i])
+			continue;
+		snap = sharedInventory.slots[i];
+		differences.push_back({ snap, int(i) });
+	}
+	return differences;
+}
+
+void CraftingTableInventoryInteraction::mergeInventories() {
+	size_t slotCount = 0;
+	for (size_t i = 0; i < 10; i++)
+		sharedInventory.slots[slotCount++] = craftInventory.slots[i];
+	for (size_t i = 9; i < 45; i++)
+		sharedInventory.slots[slotCount++] = playerInventory->slots[i];
+}
+
+void CraftingTableInventoryInteraction::updateResult() {
+	CraftingInventoryInteraction::updateResult();
+	mergeInventories();
+}
+
+void CraftingTableInventoryInteraction::shiftClickResult() {
+	ItemStack& result = craftInventory.slots[0];
+	if (result.id == ITEM_INVALID)
+		return;
+
+	ItemStack copy = result;
+	if (playerInventory->mergeItemStackInInventory(copy, true, 9, 44)) {
+		finishCraft();
+	} else {
+		craftInventory.slots[0] = copy.count == 0 ? ItemStack{} : copy;
+	}
+}
+
+void CraftingTableInventoryInteraction::shiftClickOther(int slot) {
+	auto stack = sharedInventory.getStackInSlot(slot);
+	if (!stack)
+		return;
+
+	ItemStack copy = *stack;
+
+	if (slot < 10) {
+		// Grid -> inventory
+		// Try the main inventory then the hotbar
+		bool success = playerInventory->mergeItemStackInInventory(copy, false, 9, 35);
+		if (!success)
+			playerInventory->mergeItemStackInInventory(copy, false, 36, 44);
+	} else {
+		// We can't shift click into the crafting grid itself, so just try the other area of the inventory
+		// We shift clicked in the inventory
+		if (slot > 9 && slot < 37) {
+			playerInventory->mergeItemStackInInventory(copy, false, 36, 44);
+		} else {
+			playerInventory->mergeItemStackInInventory(copy, false, 9, 35);
+		}
+	}
+
+	// Update the source in the real inventory before re-merging
+	if (slot < 10) {
+		craftInventory.slots[slot] = copy.count == 0 ? ItemStack{} : copy;
+	} else {
+		playerInventory->slots[slot - 1] = copy.count == 0 ? ItemStack{} : copy;
+	}
+
+	// Re-sync sharedInventory from the real inventories
+	mergeInventories();
+}

--- a/src/bpp_shared/inventory/interactions/crafting_table.h
+++ b/src/bpp_shared/inventory/interactions/crafting_table.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026, jwaxy <jwaxy.is-a.dev>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+*/
+#pragma once
+#include "../inventory_interaction.h"
+#include "inventory/interactions/crafting.h"
+#include "inventory/inventories.h"
+#include "runtime.h"
+#include "world.h"
+
+struct CraftingTableInventoryInteraction : CraftingInventoryInteraction {
+	InventoryCraftingTable craftInventory;
+	WorldManager& world;
+	Int3 blockPosition;
+
+	struct SharedInventory : Inventory {
+		CraftingTableInventoryInteraction* owner = nullptr;
+		SharedInventory() : Inventory(46) {}
+		void onInventoryChanged() override {
+			if (owner)
+				owner->writeBack();
+		}
+	} sharedInventory;
+
+	CraftingTableInventoryInteraction(InventoryPlayer* pinv, WorldManager& worldMng, Runtime& gameRuntime,
+	                                  Int3 craftingTablePos);
+	~CraftingTableInventoryInteraction();
+
+	bool canExist() override;
+	void initSnapshot() override;
+	std::vector<DeltaSlot> tickDiff() override;
+	void writeBack();
+
+protected:
+	void mergeInventories();
+	void updateResult() override;
+	void shiftClickResult() override;
+	void shiftClickOther(int slot) override;
+};

--- a/src/bpp_shared/inventory/interactions/player.cpp
+++ b/src/bpp_shared/inventory/interactions/player.cpp
@@ -4,15 +4,31 @@
  * SPDX-License-Identifier: AGPL-3.0-only
 */
 #include "player.h"
+#include "../../entities/entity_player.h"
+#include "inventory/interactions/crafting.h"
+#include "inventory/inventories.h"
 
-PlayerInventoryInteraction::PlayerInventoryInteraction(InventoryPlayer* inv)
-    : InventoryInteraction(inv), playerInventory(inv) {}
+PlayerInventoryInteraction::PlayerInventoryInteraction(InventoryPlayer* inv, Runtime& gameRuntime)
+    : CraftingInventoryInteraction(inv, inv, inv, gameRuntime, 2, 2), playerInventory(inv) {}
 
 bool PlayerInventoryInteraction::canExist() {
 	return playerInventory != nullptr;
 }
 
-void PlayerInventoryInteraction::onShiftClick(int slot) {
+void PlayerInventoryInteraction::shiftClickResult() {
+	ItemStack& result = playerInventory->slots[0];
+	if (result.id == ITEM_INVALID)
+		return;
+
+	ItemStack copy = result;
+	if (playerInventory->mergeItemStackInInventory(copy, true, 9, 44)) {
+		finishCraft();
+	} else {
+		playerInventory->slots[0] = copy.count == 0 ? ItemStack{} : copy;
+	}
+}
+
+void PlayerInventoryInteraction::shiftClickOther(int slot) {
 	auto from = playerInventory->getInventoryAreaFromSlot(slot);
 	auto stack = playerInventory->getStackInSlot(slot);
 	if (!stack)

--- a/src/bpp_shared/inventory/interactions/player.cpp
+++ b/src/bpp_shared/inventory/interactions/player.cpp
@@ -9,7 +9,7 @@
 #include "inventory/inventories.h"
 
 PlayerInventoryInteraction::PlayerInventoryInteraction(InventoryPlayer* inv, Runtime& gameRuntime)
-    : CraftingInventoryInteraction(inv, inv, inv, gameRuntime, 2, 2), playerInventory(inv) {}
+    : CraftingInventoryInteraction(inv, inv, inv, gameRuntime, {2, 2}), playerInventory(inv) {}
 
 bool PlayerInventoryInteraction::canExist() {
 	return playerInventory != nullptr;

--- a/src/bpp_shared/inventory/interactions/player.h
+++ b/src/bpp_shared/inventory/interactions/player.h
@@ -4,14 +4,18 @@
  * SPDX-License-Identifier: AGPL-3.0-only
 */
 #pragma once
-#include "../inventory_interaction.h"
+#include "entities/entity_player.h"
+#include "inventory/interactions/crafting.h"
 #include "inventory/inventories.h"
 
-struct PlayerInventoryInteraction : InventoryInteraction {
+struct PlayerInventoryInteraction : CraftingInventoryInteraction {
 	InventoryPlayer* playerInventory;
 
-	PlayerInventoryInteraction(InventoryPlayer* inv);
-
+	PlayerInventoryInteraction(InventoryPlayer* inv, Runtime& gameRuntime);
+	void onClose();
 	bool canExist() override;
-	void onShiftClick(int slot) override;
+
+protected:
+	void shiftClickResult() override;
+	void shiftClickOther(int slot) override;
 };

--- a/src/bpp_shared/inventory/inventories.h
+++ b/src/bpp_shared/inventory/inventories.h
@@ -15,10 +15,6 @@
 #include <optional>
 #include <random>
 
-struct EntityPlayer;
-struct Container;
-struct InventoryCrafting;
-
 enum InvMap {
 	ARMOR,
 	INVENTORY,
@@ -38,7 +34,6 @@ struct InventoryPlayer : Inventory {
 public:
 	int activeHotbarSlot = 0;
 	int currentItem = 0;
-	EntityPlayer* player = nullptr;
 
 	InventoryPlayer() : Inventory(45) {
 		name = "Inventory";
@@ -204,8 +199,8 @@ struct InventoryLargeChest : Inventory {
 	}
 };
 
-struct InventoryCrafting : Inventory {
-	InventoryCrafting() : Inventory(10) {
+struct InventoryCraftingTable : Inventory {
+	InventoryCraftingTable() : Inventory(10) {
 		name = "Crafting";
 	}
 };

--- a/src/bpp_shared/inventory/inventory.h
+++ b/src/bpp_shared/inventory/inventory.h
@@ -8,12 +8,8 @@
 #include "enums/items.h"
 #include "item_stack.h"
 #include <cstdint>
-#include <optional>
 #include <string>
 #include <vector>
-
-struct ItemStack;
-struct EntityPlayer;
 
 // Inventory
 struct Inventory {


### PR DESCRIPTION
* Seperated shared crafting behavior to a base `CraftingInventoryInteraction` that both the player and crafting table derive from.
* Renamed old `CraftingInventoryInteraction` to `CraftingTableInventoryInteraction`.
* Renamed `CraftingInventory` to `CraftingTableInventory`. 
* Fully implemented player crafting inventory.
* `PlayerEntity::dropHeldItem(int count)` generalized to `dropItem(ItemStack stack)`