### PR TITLE
Direction consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ CMakeSettings.json
 src/bpp_shared/version.h
 *.dat_old
 /vcpkg_installed
+ops.txt

--- a/src/bpp_server/packet/handle_packet.cpp
+++ b/src/bpp_server/packet/handle_packet.cpp
@@ -11,6 +11,7 @@
 #include "../trackers/entity_tracker.h"
 #include "blocks.h"
 #include "blocks/block_properties.h"
+#include "direction_fixer.h"
 #include "entities/entity_item.h"
 #include "inventory/inventory_interaction.h"
 #include "inventory/item_stack.h"
@@ -233,7 +234,8 @@ void PlaceBlock(Packet::PlaceBlock& _pkt, PlayerSession& _session, WorldManager&
 		                     heldItem->id == Items::Id::BUCKET_LAVA);
 
 		if (Items::itemBehavior[heldItem->id].onBlockUse && !isBucketItem) {
-			Items::itemBehavior[heldItem->id].onBlockUse(_world, heldItem, position, *_session.entity, _pkt.face);
+			Items::itemBehavior[heldItem->id].onBlockUse(_world, heldItem, position, *_session.entity,
+			                                             FaceDirectionToDirection(_pkt.face));
 		}
 	}
 }

--- a/src/bpp_server/packet/handle_packet.cpp
+++ b/src/bpp_server/packet/handle_packet.cpp
@@ -203,13 +203,14 @@ void PlaceBlock(Packet::PlaceBlock& _pkt, PlayerSession& _session, WorldManager&
 		bool hasOnBlockUse = static_cast<bool>(Items::itemBehavior[heldItem->id].onBlockUse);
 
 		if (isBucketItem && hasOnBlockUse) {
-			Items::itemBehavior[heldItem->id].onBlockUse(_world, heldItem, position, *_session.entity, _pkt.face);
+			Items::itemBehavior[heldItem->id].onBlockUse(_world, heldItem, position, *_session.entity,
+			                                             FaceDirectionToDirection(_pkt.face));
 		}
 		return;
 	}
 
 	if (Items::IsBlock(heldItem->id)) {
-		Int3 placePosition = Blocks::GetAdjacentBlockPos(position, _pkt.face);
+		Int3 placePosition = position.WithOffset(FaceDirectionToDirection(_pkt.face));
 
 		if (heldItem->id.value < 0 || heldItem->id.value >= 256) {
 			return;
@@ -222,7 +223,8 @@ void PlaceBlock(Packet::PlaceBlock& _pkt, PlayerSession& _session, WorldManager&
 		if (!function) {
 			return;
 		}
-		bool result = function(_world, placePosition, *_session.entity, _pkt.face, blockId, heldItem->data);
+		bool result = function(_world, placePosition, *_session.entity, FaceDirectionToDirection(_pkt.face), blockId,
+		                       heldItem->data);
 		if (result) {
 			heldItem->DecrementCount(1);
 		}

--- a/src/bpp_shared/blocks/block_behaviors.cpp
+++ b/src/bpp_shared/blocks/block_behaviors.cpp
@@ -264,7 +264,7 @@ void GenericBreak(WorldManager& _world, Int3 _pos, Entity& _destroyer) {
 bool GenericPlace(WorldManager& _world, Int3 _pos, [[maybe_unused]] Entity& _placer, Direction::Value _face,
                   BlockType _blockId, uint8_t _meta) {
 	BlockType existing = _world.GetBlockId(_pos);
-	Int3 sourceBlock = Blocks::GetSourceBlockFromFace(_pos, _face);
+	Int3 sourceBlock = _pos.WithOffset(Direction::Opposite(_face));
 
 	// Check if we can replace snow
 	Int3 targetPos = _pos;
@@ -523,28 +523,7 @@ void RegisterBlockBehaviors() {
 		    if (!IsReplaceable(_world, _pos))
 			    return false;
 
-		    int facing = 0;
-		    switch (_face) {
-		    case PacketData::Z_MINUS:
-			    facing = 0;
-			    break;
-		    case PacketData::Z_PLUS:
-			    facing = 1;
-			    break;
-		    case PacketData::X_MINUS:
-			    facing = 2;
-			    break;
-		    case PacketData::X_PLUS:
-			    facing = 3;
-			    break;
-		    default:
-			    facing = 0;
-			    break;
-		    }
-
-		    _world.SetBlock(_pos, _blockId, uint8_t(facing));
-
-		    // heldItem->DecrementCount(1) is handled by the caller when this returns true.
+		    _world.SetBlock(_pos, _blockId, GetMetaFromDirection(BLOCK_TRAPDOOR, _face));
 		    return true;
 		}
 	};
@@ -582,23 +561,8 @@ void RegisterBlockBehaviors() {
 		.getRayBounds = ButtonAabb,
 		.getCollider = EmptyCollider,
 		.onTick = [](WorldManager& _world, Int3 _pos, uint8_t _meta, Java::Random& _random) -> void {
-		    Direction::Value trueFace = Direction::Value::INVALID_USE;
-		    switch (_meta & 0b111) {
-		    case 1:
-			    trueFace = Direction::Value::X_PLUS;
-			    break;
-		    case 2:
-			    trueFace = Direction::Value::X_MINUS;
-			    break;
-		    case 3:
-			    trueFace = Direction::Value::Z_PLUS;
-			    break;
-		    case 4:
-			    trueFace = Direction::Value::Z_MINUS;
-			    break;
-		    }
 		    // Check to make sure we can till exist here
-		    if (!IsSupported(_world, _pos, trueFace))
+		    if (!IsSupported(_world, _pos, GetDirectionFromMeta(BLOCK_BUTTON_STONE, _meta)))
 			    BreakAndDropBlock(_world, _pos);
 		    // Unpress again
 		    if (_meta & 0b1000) {
@@ -623,12 +587,9 @@ void RegisterBlockBehaviors() {
 		    // Buttons can only be placed against the sides of blocks
 		    if (_face == Direction::Value::Up || _face == Direction::Value::Down)
 			    return false;
-
 		    if (!IsReplaceable(_world, _pos))
 			    return false;
-		    const uint8_t meta = GetMetaFromDirection(BLOCK_BUTTON_STONE, FaceDirectionToDirection(_face));
-		    GlobalLogger().info << int(_face) << ": " << int(meta) << "\n";
-		    _world.SetBlock(_pos, _blockId, meta);
+		    _world.SetBlock(_pos, _blockId, GetMetaFromDirection(BLOCK_BUTTON_STONE, _face));
 		    return true;
 		},
 	};
@@ -837,10 +798,10 @@ void RegisterBlockBehaviors() {
 	// Slabs
 	blockBehaviors[BLOCK_SLAB].onBlockPlaced = [](WorldManager& _world, Int3 _pos, Entity& _placer,
 	                                              Direction::Value _face, BlockType _blockId, uint8_t _meta) -> bool {
-		auto sourcePos = GetSourceBlockFromFace(_pos, _face);
+		auto sourcePos = _pos.WithOffset(Direction::Opposite(_face));
 		auto sourceBlock = _world.GetBlockId(sourcePos);
 		auto sourceMeta = _world.GetMetadata(sourcePos);
-		if (sourceBlock == BLOCK_SLAB && _face == Direction::Value::Y_PLUS && sourceMeta == _meta) {
+		if (sourceBlock == BLOCK_SLAB && _face == Direction::Value::Up && sourceMeta == _meta) {
 			_world.SetBlock(sourcePos, BLOCK_AIR);
 			return GenericPlace(_world, sourcePos, _placer, _face, BLOCK_DOUBLE_SLAB, _meta);
 		}
@@ -884,15 +845,15 @@ void RegisterBlockBehaviors() {
 	blockBehaviors[BLOCK_LADDER].onBlockPlaced = [](WorldManager& _world, Int3 _pos, Entity& _placer,
 	                                                Direction::Value _face, BlockType _blockId, uint8_t _meta) -> bool {
 		Int3 targetPos = _pos;
-		const Int3 sourceBlock = Blocks::GetSourceBlockFromFace(_pos, _face);
+		const Int3 sourceBlock = _pos.WithOffset(Direction::Opposite(_face));
 		if (_world.GetBlockId(sourceBlock) == BLOCK_SNOW_LAYER)
 			targetPos = sourceBlock;
 
 		static constexpr std::array<Direction::Value, 4> CHECK_ORDER = {
-			Direction::Value::Z_MINUS, Direction::Value::Z_PLUS, Direction::Value::X_MINUS, Direction::Value::X_PLUS
+			Direction::Value::North, Direction::Value::South, Direction::Value::West, Direction::Value::East
 		};
 
-		if (_face >= 2 && IsSupported(_world, _pos, _face)) {
+		if (Direction::IsHorizontal(_face) && IsSupported(_world, _pos, _face)) {
 			return GenericPlace(_world, _pos, _placer, _face, _blockId, uint8_t(_face));
 		}
 
@@ -907,29 +868,30 @@ void RegisterBlockBehaviors() {
 	blockBehaviors[BLOCK_REDSTONE_TORCH_ON].onBlockPlaced = [](WorldManager& _world, Int3 _pos, Entity& _placer,
 	                                                           Direction::Value _face, BlockType _blockId,
 	                                                           uint8_t _meta) -> bool {
-		if (_world.GetBlockId(Blocks::GetSourceBlockFromFace(_pos, _face)) == BLOCK_SNOW_LAYER)
-			_pos = Blocks::GetSourceBlockFromFace(_pos, _face);
+		if (_world.GetBlockId(_pos.WithOffset(Direction::Opposite(_face))) == BLOCK_SNOW_LAYER)
+			_pos = _pos.WithOffset(Direction::Opposite(_face));
 		if (CanTorchAttachTo(_world, _pos, _face)) {
-			return GenericPlace(_world, _pos, _placer, _face, _blockId, 6 - _face);
+			return GenericPlace(_world, _pos, _placer, _face, _blockId,
+			                    GetMetaFromDirection(BLOCK_REDSTONE_TORCH_ON, Direction::Opposite(_face)));
 		}
 		return false;
 	};
 
 	blockBehaviors[BLOCK_REDSTONE_TORCH_ON].onBlockAdded = [](WorldManager& _world, Int3 _pos) -> void {
-		const auto currentFace = static_cast<Direction::Value>(6 - _world.GetMetadata(_pos));
+		const auto currentFace = Direction::Opposite(
+		    GetDirectionFromMeta(BLOCK_REDSTONE_TORCH_ON, _world.GetMetadata(_pos)));
 		if (CanTorchAttachTo(_world, _pos, currentFace))
 			return; // Already valid
 
 		// Matches vanilla order
-		static constexpr std::array<Direction::Value, 5> CHECK_ORDER = {
-			Direction::Value::X_PLUS, Direction::Value::X_MINUS, Direction::Value::Z_PLUS, Direction::Value::Z_MINUS,
-			Direction::Value::Y_PLUS
-		};
+		static constexpr std::array<Direction::Value, 5> CHECK_ORDER = { Direction::Value::East, Direction::Value::West,
+			                                                             Direction::Value::South,
+			                                                             Direction::Value::North, Direction::Value::Up };
 
 		// Attach to the first support block we find
 		for (Direction::Value face : CHECK_ORDER) {
 			if (CanTorchAttachTo(_world, _pos, face)) {
-				_world.SetMeta(_pos, 6 - face);
+				_world.SetMeta(_pos, GetMetaFromDirection(BLOCK_REDSTONE_TORCH_ON, Direction::Opposite(face)));
 				return;
 			}
 		}
@@ -952,13 +914,13 @@ void RegisterBlockBehaviors() {
 
 	blockBehaviors[BLOCK_REDSTONE_TORCH_ON].onTick = [](WorldManager& _world, Int3 _pos, uint8_t _meta,
 	                                                    Java::Random& _random) -> void {
-		auto supportFace = static_cast<Direction::Value>(6 - _meta);
+		auto supportFace = Direction::Opposite(GetDirectionFromMeta(BLOCK_REDSTONE_TORCH_ON, _meta));
 		if (!CanTorchAttachTo(_world, _pos, supportFace)) {
 			BreakAndDropBlock(_world, _pos);
 			return;
 		}
 
-		Int3 supportPos = _pos.WithOffset(PacketData::OppositeFace(supportFace));
+		Int3 supportPos = _pos.WithOffset(Direction::Opposite(supportFace));
 
 		// turn OFF the instant the block it's mounted on is powered
 		if (RedstoneManager::GetBlockPowerProfile(_world, supportPos).powered) {
@@ -967,18 +929,17 @@ void RegisterBlockBehaviors() {
 	};
 
 	blockBehaviors[BLOCK_REDSTONE_TORCH_OFF].onBlockAdded = [](WorldManager& _world, Int3 _pos) -> void {
-		auto currentFace = static_cast<Direction::Value>(6 - _world.GetMetadata(_pos));
+		auto currentFace = GetDirectionFromMeta(BLOCK_REDSTONE_TORCH_OFF, _world.GetMetadata(_pos));
 		if (CanTorchAttachTo(_world, _pos, currentFace))
 			return; // Already valid
 
-		static constexpr std::array<Direction::Value, 5> CHECK_ORDER = {
-			Direction::Value::X_PLUS, Direction::Value::X_MINUS, Direction::Value::Z_PLUS, Direction::Value::Z_MINUS,
-			Direction::Value::Y_PLUS
-		};
+		static constexpr std::array<Direction::Value, 5> CHECK_ORDER = { Direction::Value::East, Direction::Value::West,
+			                                                             Direction::Value::South,
+			                                                             Direction::Value::North, Direction::Value::Up };
 
 		for (Direction::Value face : CHECK_ORDER) {
 			if (CanTorchAttachTo(_world, _pos, face)) {
-				_world.SetMeta(_pos, 6 - face);
+				_world.SetMeta(_pos, GetMetaFromDirection(BLOCK_REDSTONE_TORCH_OFF, Direction::Opposite(face)));
 				return;
 			}
 		}
@@ -1000,13 +961,13 @@ void RegisterBlockBehaviors() {
 
 	blockBehaviors[BLOCK_REDSTONE_TORCH_OFF].onTick = [](WorldManager& _world, Int3 _pos, uint8_t _meta,
 	                                                     Java::Random& _random) -> void {
-		auto supportFace = static_cast<Direction::Value>(6 - _meta);
+		auto supportFace = Direction::Opposite(GetDirectionFromMeta(BLOCK_REDSTONE_TORCH_OFF, _meta));
 		if (!CanTorchAttachTo(_world, _pos, supportFace)) {
 			BreakAndDropBlock(_world, _pos);
 			return;
 		}
 
-		Int3 supportPos = _pos.WithOffset(PacketData::OppositeFace(supportFace));
+		Int3 supportPos = _pos.WithOffset(Direction::Opposite(supportFace));
 
 		// An unlit torch turns back ON the instant the block it's mounted on is no longer powered
 		if (!RedstoneManager::GetBlockPowerProfile(_world, supportPos).powered) {
@@ -1096,29 +1057,29 @@ void RegisterBlockBehaviors() {
 
 	blockBehaviors[BLOCK_TORCH].onBlockPlaced = [](WorldManager& _world, Int3 _pos, Entity& _placer,
 	                                               Direction::Value _face, BlockType _blockId, uint8_t _meta) -> bool {
-		if (_world.GetBlockId(Blocks::GetSourceBlockFromFace(_pos, _face)) == BLOCK_SNOW_LAYER)
-			_pos = Blocks::GetSourceBlockFromFace(_pos, _face);
+		if (_world.GetBlockId(_pos.WithOffset(Direction::Opposite(_face))) == BLOCK_SNOW_LAYER)
+			_pos = _pos.WithOffset(Direction::Opposite(_face));
 		if (CanTorchAttachTo(_world, _pos, _face)) {
-			return GenericPlace(_world, _pos, _placer, _face, _blockId, 6 - _face);
+			return GenericPlace(_world, _pos, _placer, _face, _blockId,
+			                    GetMetaFromDirection(BLOCK_TORCH, Direction::Opposite(_face)));
 		}
 		return false;
 	};
 
 	blockBehaviors[BLOCK_TORCH].onBlockAdded = [](WorldManager& _world, Int3 _pos) -> void {
-		auto currentFace = static_cast<Direction::Value>(6 - _world.GetMetadata(_pos));
+		auto currentFace = Direction::Opposite(GetDirectionFromMeta(BLOCK_TORCH, _world.GetMetadata(_pos)));
 		if (CanTorchAttachTo(_world, _pos, currentFace))
 			return; // Already valid
 
 		// Matches vanilla order
-		static constexpr std::array<Direction::Value, 5> CHECK_ORDER = {
-			Direction::Value::X_PLUS, Direction::Value::X_MINUS, Direction::Value::Z_PLUS, Direction::Value::Z_MINUS,
-			Direction::Value::Y_PLUS
-		};
+		static constexpr std::array<Direction::Value, 5> CHECK_ORDER = { Direction::Value::East, Direction::Value::West,
+			                                                             Direction::Value::South,
+			                                                             Direction::Value::North, Direction::Value::Up };
 
 		// Attach to the first support block we find
 		for (Direction::Value face : CHECK_ORDER) {
 			if (CanTorchAttachTo(_world, _pos, face)) {
-				_world.SetMeta(_pos, 6 - face);
+				_world.SetMeta(_pos, GetMetaFromDirection(BLOCK_TORCH, Direction::Opposite(face)));
 				return;
 			}
 		}
@@ -1127,8 +1088,7 @@ void RegisterBlockBehaviors() {
 	};
 
 	blockBehaviors[BLOCK_TORCH].onNeighborBlockChange = [](WorldManager& _world, Int3 _pos, BlockType _blockId) -> void {
-		uint8_t meta = _world.GetMetadata(_pos);
-		auto supportFace = static_cast<Direction::Value>(6 - meta);
+		auto supportFace = GetDirectionFromMeta(BLOCK_TORCH, _world.GetMetadata(_pos));
 		if (!CanTorchAttachTo(_world, _pos, supportFace))
 			BreakAndDropBlock(_world, _pos);
 	};
@@ -1136,7 +1096,7 @@ void RegisterBlockBehaviors() {
 	auto onDoorPlace = [](WorldManager& _world, Int3 _pos, Entity& _placer, Direction::Value _face, BlockType _blockId,
 	                      uint8_t _meta) -> bool {
 		// Doors can only be placed by clicking the top face of a block
-		if (_face != Direction::Value::Y_PLUS)
+		if (_face != Direction::Value::Up)
 			return false;
 
 		// _pos is already the target cell
@@ -1221,7 +1181,7 @@ void RegisterBlockBehaviors() {
 	blockBehaviors[BLOCK_BED].onBlockPlaced = [](WorldManager& _world, Int3 _pos, Entity& _placer,
 	                                             Direction::Value _face, BlockType _blockId, uint8_t _meta) -> bool {
 		// Beds can only be placed by clicking the top face of a block
-		if (_face != Direction::Value::Y_PLUS)
+		if (_face != Direction::Value::Up)
 			return false;
 
 		// _pos is already the target cell

--- a/src/bpp_shared/blocks/block_behaviors.cpp
+++ b/src/bpp_shared/blocks/block_behaviors.cpp
@@ -839,7 +839,7 @@ void RegisterBlockBehaviors() {
 	blockBehaviors[BLOCK_LADDER].onTick = [](WorldManager& _world, Int3 _pos, uint8_t _meta,
 	                                         Java::Random& _random) -> void {
 		// Check to make sure we can till exist here
-		if (!IsSupported(_world, _pos, Direction::Value(_meta)))
+		if (!IsSupported(_world, _pos, GetDirectionFromMeta(BLOCK_LADDER, _meta)))
 			BreakAndDropBlock(_world, _pos);
 	};
 	blockBehaviors[BLOCK_LADDER].onBlockPlaced = [](WorldManager& _world, Int3 _pos, Entity& _placer,
@@ -872,14 +872,13 @@ void RegisterBlockBehaviors() {
 			_pos = _pos.WithOffset(Direction::Opposite(_face));
 		if (CanTorchAttachTo(_world, _pos, _face)) {
 			return GenericPlace(_world, _pos, _placer, _face, _blockId,
-			                    GetMetaFromDirection(BLOCK_REDSTONE_TORCH_ON, Direction::Opposite(_face)));
+			                    GetMetaFromDirection(BLOCK_REDSTONE_TORCH_ON, _face));
 		}
 		return false;
 	};
 
 	blockBehaviors[BLOCK_REDSTONE_TORCH_ON].onBlockAdded = [](WorldManager& _world, Int3 _pos) -> void {
-		const auto currentFace = Direction::Opposite(
-		    GetDirectionFromMeta(BLOCK_REDSTONE_TORCH_ON, _world.GetMetadata(_pos)));
+		const auto currentFace = GetDirectionFromMeta(BLOCK_REDSTONE_TORCH_ON, _world.GetMetadata(_pos));
 		if (CanTorchAttachTo(_world, _pos, currentFace))
 			return; // Already valid
 
@@ -891,7 +890,7 @@ void RegisterBlockBehaviors() {
 		// Attach to the first support block we find
 		for (Direction::Value face : CHECK_ORDER) {
 			if (CanTorchAttachTo(_world, _pos, face)) {
-				_world.SetMeta(_pos, GetMetaFromDirection(BLOCK_REDSTONE_TORCH_ON, Direction::Opposite(face)));
+				_world.SetMeta(_pos, GetMetaFromDirection(BLOCK_REDSTONE_TORCH_ON, face));
 				return;
 			}
 		}
@@ -902,7 +901,7 @@ void RegisterBlockBehaviors() {
 	blockBehaviors[BLOCK_REDSTONE_TORCH_ON].onNeighborBlockChange = [](WorldManager& _world, Int3 _pos,
 	                                                                   BlockType _blockId) -> void {
 		uint8_t meta = _world.GetMetadata(_pos);
-		auto supportFace = static_cast<Direction::Value>(6 - meta);
+		auto supportFace = GetDirectionFromMeta(BLOCK_REDSTONE_TORCH_ON, meta);
 		if (!CanTorchAttachTo(_world, _pos, supportFace)) {
 			BreakAndDropBlock(_world, _pos);
 			return;
@@ -914,7 +913,7 @@ void RegisterBlockBehaviors() {
 
 	blockBehaviors[BLOCK_REDSTONE_TORCH_ON].onTick = [](WorldManager& _world, Int3 _pos, uint8_t _meta,
 	                                                    Java::Random& _random) -> void {
-		auto supportFace = Direction::Opposite(GetDirectionFromMeta(BLOCK_REDSTONE_TORCH_ON, _meta));
+		auto supportFace = GetDirectionFromMeta(BLOCK_REDSTONE_TORCH_ON, _meta);
 		if (!CanTorchAttachTo(_world, _pos, supportFace)) {
 			BreakAndDropBlock(_world, _pos);
 			return;
@@ -939,7 +938,7 @@ void RegisterBlockBehaviors() {
 
 		for (Direction::Value face : CHECK_ORDER) {
 			if (CanTorchAttachTo(_world, _pos, face)) {
-				_world.SetMeta(_pos, GetMetaFromDirection(BLOCK_REDSTONE_TORCH_OFF, Direction::Opposite(face)));
+				_world.SetMeta(_pos, GetMetaFromDirection(BLOCK_REDSTONE_TORCH_OFF, face));
 				return;
 			}
 		}
@@ -950,7 +949,7 @@ void RegisterBlockBehaviors() {
 	blockBehaviors[BLOCK_REDSTONE_TORCH_OFF].onNeighborBlockChange = [](WorldManager& _world, Int3 _pos,
 	                                                                    BlockType _blockId) -> void {
 		uint8_t meta = _world.GetMetadata(_pos);
-		auto supportFace = static_cast<Direction::Value>(6 - meta);
+		auto supportFace = GetDirectionFromMeta(BLOCK_REDSTONE_TORCH_OFF, meta);
 		if (!CanTorchAttachTo(_world, _pos, supportFace)) {
 			BreakAndDropBlock(_world, _pos);
 			return;
@@ -961,7 +960,7 @@ void RegisterBlockBehaviors() {
 
 	blockBehaviors[BLOCK_REDSTONE_TORCH_OFF].onTick = [](WorldManager& _world, Int3 _pos, uint8_t _meta,
 	                                                     Java::Random& _random) -> void {
-		auto supportFace = Direction::Opposite(GetDirectionFromMeta(BLOCK_REDSTONE_TORCH_OFF, _meta));
+		auto supportFace = GetDirectionFromMeta(BLOCK_REDSTONE_TORCH_OFF, _meta);
 		if (!CanTorchAttachTo(_world, _pos, supportFace)) {
 			BreakAndDropBlock(_world, _pos);
 			return;
@@ -1061,13 +1060,13 @@ void RegisterBlockBehaviors() {
 			_pos = _pos.WithOffset(Direction::Opposite(_face));
 		if (CanTorchAttachTo(_world, _pos, _face)) {
 			return GenericPlace(_world, _pos, _placer, _face, _blockId,
-			                    GetMetaFromDirection(BLOCK_TORCH, Direction::Opposite(_face)));
+			                    GetMetaFromDirection(BLOCK_TORCH, _face));
 		}
 		return false;
 	};
 
 	blockBehaviors[BLOCK_TORCH].onBlockAdded = [](WorldManager& _world, Int3 _pos) -> void {
-		auto currentFace = Direction::Opposite(GetDirectionFromMeta(BLOCK_TORCH, _world.GetMetadata(_pos)));
+		auto currentFace = GetDirectionFromMeta(BLOCK_TORCH, _world.GetMetadata(_pos));
 		if (CanTorchAttachTo(_world, _pos, currentFace))
 			return; // Already valid
 
@@ -1079,7 +1078,7 @@ void RegisterBlockBehaviors() {
 		// Attach to the first support block we find
 		for (Direction::Value face : CHECK_ORDER) {
 			if (CanTorchAttachTo(_world, _pos, face)) {
-				_world.SetMeta(_pos, GetMetaFromDirection(BLOCK_TORCH, Direction::Opposite(face)));
+				_world.SetMeta(_pos, GetMetaFromDirection(BLOCK_TORCH, face));
 				return;
 			}
 		}

--- a/src/bpp_shared/blocks/block_behaviors.cpp
+++ b/src/bpp_shared/blocks/block_behaviors.cpp
@@ -854,12 +854,12 @@ void RegisterBlockBehaviors() {
 		};
 
 		if (Direction::IsHorizontal(_face) && IsSupported(_world, _pos, _face)) {
-			return GenericPlace(_world, _pos, _placer, _face, _blockId, uint8_t(_face));
+			return GenericPlace(_world, _pos, _placer, _face, _blockId, GetMetaFromDirection(BLOCK_LADDER, _face));
 		}
 
 		for (Direction::Value dir : CHECK_ORDER) {
 			if (IsSupported(_world, _pos, dir)) {
-				return GenericPlace(_world, _pos, _placer, _face, _blockId, uint8_t(dir));
+				return GenericPlace(_world, _pos, _placer, _face, _blockId, GetMetaFromDirection(BLOCK_LADDER, dir));
 			}
 		}
 		return false;

--- a/src/bpp_shared/blocks/block_behaviors.cpp
+++ b/src/bpp_shared/blocks/block_behaviors.cpp
@@ -523,7 +523,7 @@ void RegisterBlockBehaviors() {
 		    if (!IsReplaceable(_world, _pos))
 			    return false;
 
-		    _world.SetBlock(_pos, _blockId, GetMetaFromDirection(BLOCK_TRAPDOOR, _face));
+		    _world.SetBlock(_pos, _blockId, GetMetaFromDirection(BLOCK_TRAPDOOR, Direction::Opposite(_face)));
 		    return true;
 		}
 	};

--- a/src/bpp_shared/blocks/block_behaviors.cpp
+++ b/src/bpp_shared/blocks/block_behaviors.cpp
@@ -900,9 +900,8 @@ void RegisterBlockBehaviors() {
 
 	blockBehaviors[BLOCK_REDSTONE_TORCH_ON].onNeighborBlockChange = [](WorldManager& _world, Int3 _pos,
 	                                                                   BlockType _blockId) -> void {
-		uint8_t meta = _world.GetMetadata(_pos);
-		auto supportFace = GetDirectionFromMeta(BLOCK_REDSTONE_TORCH_ON, meta);
-		if (!CanTorchAttachTo(_world, _pos, supportFace)) {
+		auto dir = GetDirectionFromMeta(BLOCK_REDSTONE_TORCH_ON, _world.GetMetadata(_pos));
+		if (!CanTorchAttachTo(_world, _pos, dir)) {
 			BreakAndDropBlock(_world, _pos);
 			return;
 		}
@@ -913,13 +912,13 @@ void RegisterBlockBehaviors() {
 
 	blockBehaviors[BLOCK_REDSTONE_TORCH_ON].onTick = [](WorldManager& _world, Int3 _pos, uint8_t _meta,
 	                                                    Java::Random& _random) -> void {
-		auto supportFace = GetDirectionFromMeta(BLOCK_REDSTONE_TORCH_ON, _meta);
-		if (!CanTorchAttachTo(_world, _pos, supportFace)) {
+		const auto dir = GetDirectionFromMeta(BLOCK_REDSTONE_TORCH_ON, _meta);
+		if (!CanTorchAttachTo(_world, _pos, dir)) {
 			BreakAndDropBlock(_world, _pos);
 			return;
 		}
 
-		Int3 supportPos = _pos.WithOffset(Direction::Opposite(supportFace));
+		Int3 supportPos = _pos.WithOffset(Direction::Opposite(dir));
 
 		// turn OFF the instant the block it's mounted on is powered
 		if (RedstoneManager::GetBlockPowerProfile(_world, supportPos).powered) {
@@ -928,8 +927,8 @@ void RegisterBlockBehaviors() {
 	};
 
 	blockBehaviors[BLOCK_REDSTONE_TORCH_OFF].onBlockAdded = [](WorldManager& _world, Int3 _pos) -> void {
-		auto currentFace = GetDirectionFromMeta(BLOCK_REDSTONE_TORCH_OFF, _world.GetMetadata(_pos));
-		if (CanTorchAttachTo(_world, _pos, currentFace))
+		const auto dir = GetDirectionFromMeta(BLOCK_REDSTONE_TORCH_OFF, _world.GetMetadata(_pos));
+		if (CanTorchAttachTo(_world, _pos, dir))
 			return; // Already valid
 
 		static constexpr std::array<Direction::Value, 5> CHECK_ORDER = { Direction::Value::East, Direction::Value::West,
@@ -948,9 +947,8 @@ void RegisterBlockBehaviors() {
 
 	blockBehaviors[BLOCK_REDSTONE_TORCH_OFF].onNeighborBlockChange = [](WorldManager& _world, Int3 _pos,
 	                                                                    BlockType _blockId) -> void {
-		uint8_t meta = _world.GetMetadata(_pos);
-		auto supportFace = GetDirectionFromMeta(BLOCK_REDSTONE_TORCH_OFF, meta);
-		if (!CanTorchAttachTo(_world, _pos, supportFace)) {
+		const auto dir = GetDirectionFromMeta(BLOCK_REDSTONE_TORCH_OFF, _world.GetMetadata(_pos));
+		if (!CanTorchAttachTo(_world, _pos, dir)) {
 			BreakAndDropBlock(_world, _pos);
 			return;
 		}
@@ -960,13 +958,13 @@ void RegisterBlockBehaviors() {
 
 	blockBehaviors[BLOCK_REDSTONE_TORCH_OFF].onTick = [](WorldManager& _world, Int3 _pos, uint8_t _meta,
 	                                                     Java::Random& _random) -> void {
-		auto supportFace = GetDirectionFromMeta(BLOCK_REDSTONE_TORCH_OFF, _meta);
-		if (!CanTorchAttachTo(_world, _pos, supportFace)) {
+		const auto dir = GetDirectionFromMeta(BLOCK_REDSTONE_TORCH_OFF, _meta);
+		if (!CanTorchAttachTo(_world, _pos, dir)) {
 			BreakAndDropBlock(_world, _pos);
 			return;
 		}
 
-		Int3 supportPos = _pos.WithOffset(Direction::Opposite(supportFace));
+		Int3 supportPos = _pos.WithOffset(Direction::Opposite(dir));
 
 		// An unlit torch turns back ON the instant the block it's mounted on is no longer powered
 		if (!RedstoneManager::GetBlockPowerProfile(_world, supportPos).powered) {
@@ -1066,7 +1064,7 @@ void RegisterBlockBehaviors() {
 	};
 
 	blockBehaviors[BLOCK_TORCH].onBlockAdded = [](WorldManager& _world, Int3 _pos) -> void {
-		auto currentFace = GetDirectionFromMeta(BLOCK_TORCH, _world.GetMetadata(_pos));
+		const auto currentFace = GetDirectionFromMeta(BLOCK_TORCH, _world.GetMetadata(_pos));
 		if (CanTorchAttachTo(_world, _pos, currentFace))
 			return; // Already valid
 
@@ -1087,8 +1085,8 @@ void RegisterBlockBehaviors() {
 	};
 
 	blockBehaviors[BLOCK_TORCH].onNeighborBlockChange = [](WorldManager& _world, Int3 _pos, BlockType _blockId) -> void {
-		auto supportFace = GetDirectionFromMeta(BLOCK_TORCH, _world.GetMetadata(_pos));
-		if (!CanTorchAttachTo(_world, _pos, supportFace))
+		const auto dir = GetDirectionFromMeta(BLOCK_TORCH, _world.GetMetadata(_pos));
+		if (!CanTorchAttachTo(_world, _pos, dir))
 			BreakAndDropBlock(_world, _pos);
 	};
 

--- a/src/bpp_shared/blocks/block_behaviors.cpp
+++ b/src/bpp_shared/blocks/block_behaviors.cpp
@@ -38,8 +38,8 @@ static bool IsReplaceable(WorldManager& _world, Int3 _pos) {
 	       existing == BLOCK_SNOW_LAYER;
 };
 
-static bool IsSupported(WorldManager& _world, Int3 _pos, PacketData::FaceDirection _dir) {
-	Int3 support = GetAdjacentBlockPos(_pos, PacketData::OppositeFace(_dir));
+static bool IsSupported(WorldManager& _world, Int3 _pos, Direction::Value _dir) {
+	Int3 support = _pos.WithOffset(Direction::Opposite(_dir));
 	return _world.IsBlockNormalCube(support);
 };
 
@@ -261,7 +261,7 @@ void GenericBreak(WorldManager& _world, Int3 _pos, Entity& _destroyer) {
 	BreakAndDropBlock(_world, _pos);
 }
 
-bool GenericPlace(WorldManager& _world, Int3 _pos, [[maybe_unused]] Entity& _placer, PacketData::FaceDirection _face,
+bool GenericPlace(WorldManager& _world, Int3 _pos, [[maybe_unused]] Entity& _placer, Direction::Value _face,
                   BlockType _blockId, uint8_t _meta) {
 	BlockType existing = _world.GetBlockId(_pos);
 	Int3 sourceBlock = Blocks::GetSourceBlockFromFace(_pos, _face);
@@ -514,10 +514,10 @@ void RegisterBlockBehaviors() {
 		    ToggleTrapdoor(_world, _pos);
 		    return false;
 		},
-		.onBlockPlaced = [](WorldManager& _world, Int3 _pos, Entity& _placer, PacketData::FaceDirection _face,
+		.onBlockPlaced = [](WorldManager& _world, Int3 _pos, Entity& _placer, Direction::Value _face,
 		                    BlockType _blockId, uint8_t _meta) -> bool {
 		    // Doors can only be placed against the sides of blocks
-		    if (_face == PacketData::FaceDirection::Y_PLUS || _face == PacketData::FaceDirection::Y_MINUS)
+		    if (_face == Direction::Value::Up || _face == Direction::Value::Down)
 			    return false;
 
 		    if (!IsReplaceable(_world, _pos))
@@ -582,19 +582,19 @@ void RegisterBlockBehaviors() {
 		.getRayBounds = ButtonAabb,
 		.getCollider = EmptyCollider,
 		.onTick = [](WorldManager& _world, Int3 _pos, uint8_t _meta, Java::Random& _random) -> void {
-		    PacketData::FaceDirection trueFace = PacketData::FaceDirection::INVALID_USE;
+		    Direction::Value trueFace = Direction::Value::INVALID_USE;
 		    switch (_meta & 0b111) {
 		    case 1:
-			    trueFace = PacketData::FaceDirection::X_PLUS;
+			    trueFace = Direction::Value::X_PLUS;
 			    break;
 		    case 2:
-			    trueFace = PacketData::FaceDirection::X_MINUS;
+			    trueFace = Direction::Value::X_MINUS;
 			    break;
 		    case 3:
-			    trueFace = PacketData::FaceDirection::Z_PLUS;
+			    trueFace = Direction::Value::Z_PLUS;
 			    break;
 		    case 4:
-			    trueFace = PacketData::FaceDirection::Z_MINUS;
+			    trueFace = Direction::Value::Z_MINUS;
 			    break;
 		    }
 		    // Check to make sure we can till exist here
@@ -618,10 +618,10 @@ void RegisterBlockBehaviors() {
 		    blockBehaviors[BLOCK_BUTTON_STONE].onBlockClicked(_world, _pos, _triggeringSession);
 		    return false;
 		},
-		.onBlockPlaced = [](WorldManager& _world, Int3 _pos, Entity& _placer, PacketData::FaceDirection _face,
+		.onBlockPlaced = [](WorldManager& _world, Int3 _pos, Entity& _placer, Direction::Value _face,
 		                    BlockType _blockId, uint8_t _meta) -> bool {
 		    // Buttons can only be placed against the sides of blocks
-		    if (_face == PacketData::FaceDirection::Y_PLUS || _face == PacketData::FaceDirection::Y_MINUS)
+		    if (_face == Direction::Value::Up || _face == Direction::Value::Down)
 			    return false;
 
 		    if (!IsReplaceable(_world, _pos))
@@ -722,13 +722,13 @@ void RegisterBlockBehaviors() {
 	};
 
 	// Placement overrides
-	auto onFurnaceDispenserPlace = [](WorldManager& _world, Int3 _pos, Entity& _placer, PacketData::FaceDirection _face,
+	auto onFurnaceDispenserPlace = [](WorldManager& _world, Int3 _pos, Entity& _placer, Direction::Value _face,
 	                                  BlockType _blockId, uint8_t _meta) -> bool {
 		int meta[] = { 2, 5, 3, 4 };
 		return GenericPlace(_world, _pos, _placer, _face, _blockId, meta[GetDirectionFromYaw(_placer.rotationYaw, 4)]);
 	};
 
-	auto onPumpkinPlace = [](WorldManager& _world, Int3 _pos, Entity& _placer, PacketData::FaceDirection _face,
+	auto onPumpkinPlace = [](WorldManager& _world, Int3 _pos, Entity& _placer, Direction::Value _face,
 	                         BlockType _blockId, uint8_t _meta) -> bool {
 		int meta[] = { 2, 3, 0, 1 };
 		auto belowBlockMaterial = _world.GetMaterial({ _pos.x, _pos.y - 1, _pos.z });
@@ -737,21 +737,21 @@ void RegisterBlockBehaviors() {
 		return GenericPlace(_world, _pos, _placer, _face, _blockId, meta[GetDirectionFromYaw(_placer.rotationYaw, 4)]);
 	};
 
-	auto onStairPlace = [](WorldManager& _world, Int3 _pos, Entity& _placer, PacketData::FaceDirection _face,
-	                       BlockType _blockId, uint8_t _meta) -> bool {
+	auto onStairPlace = [](WorldManager& _world, Int3 _pos, Entity& _placer, Direction::Value _face, BlockType _blockId,
+	                       uint8_t _meta) -> bool {
 		int meta[] = { 2, 1, 3, 0 };
 		return GenericPlace(_world, _pos, _placer, _face, _blockId, meta[GetDirectionFromYaw(_placer.rotationYaw, 4)]);
 	};
 
-	auto onPlantPlace = [](WorldManager& _world, Int3 _pos, Entity& _placer, PacketData::FaceDirection _face,
-	                       BlockType _blockId, uint8_t _meta) -> bool {
+	auto onPlantPlace = [](WorldManager& _world, Int3 _pos, Entity& _placer, Direction::Value _face, BlockType _blockId,
+	                       uint8_t _meta) -> bool {
 		if (CanGenericPlantSurviveAt(_world, _pos)) {
 			return GenericPlace(_world, _pos, _placer, _face, _blockId, _meta);
 		}
 		return false;
 	};
 
-	auto onMushroomPlace = [](WorldManager& _world, Int3 _pos, Entity& _placer, PacketData::FaceDirection _face,
+	auto onMushroomPlace = [](WorldManager& _world, Int3 _pos, Entity& _placer, Direction::Value _face,
 	                          BlockType _blockId, uint8_t _meta) -> bool {
 		if (CanMushroomSurviveAt(_world, _pos)) {
 			return GenericPlace(_world, _pos, _placer, _face, _blockId, _meta);
@@ -759,7 +759,7 @@ void RegisterBlockBehaviors() {
 		return false;
 	};
 
-	auto onCactusPlace = [](WorldManager& _world, Int3 _pos, Entity& _placer, PacketData::FaceDirection _face,
+	auto onCactusPlace = [](WorldManager& _world, Int3 _pos, Entity& _placer, Direction::Value _face,
 	                        BlockType _blockId, uint8_t _meta) -> bool {
 		if (CanCactusSurviveAt(_world, _pos)) {
 			return GenericPlace(_world, _pos, _placer, _face, _blockId, _meta);
@@ -836,12 +836,11 @@ void RegisterBlockBehaviors() {
 
 	// Slabs
 	blockBehaviors[BLOCK_SLAB].onBlockPlaced = [](WorldManager& _world, Int3 _pos, Entity& _placer,
-	                                              PacketData::FaceDirection _face, BlockType _blockId,
-	                                              uint8_t _meta) -> bool {
+	                                              Direction::Value _face, BlockType _blockId, uint8_t _meta) -> bool {
 		auto sourcePos = GetSourceBlockFromFace(_pos, _face);
 		auto sourceBlock = _world.GetBlockId(sourcePos);
 		auto sourceMeta = _world.GetMetadata(sourcePos);
-		if (sourceBlock == BLOCK_SLAB && _face == PacketData::FaceDirection::Y_PLUS && sourceMeta == _meta) {
+		if (sourceBlock == BLOCK_SLAB && _face == Direction::Value::Y_PLUS && sourceMeta == _meta) {
 			_world.SetBlock(sourcePos, BLOCK_AIR);
 			return GenericPlace(_world, sourcePos, _placer, _face, BLOCK_DOUBLE_SLAB, _meta);
 		}
@@ -879,27 +878,25 @@ void RegisterBlockBehaviors() {
 	blockBehaviors[BLOCK_LADDER].onTick = [](WorldManager& _world, Int3 _pos, uint8_t _meta,
 	                                         Java::Random& _random) -> void {
 		// Check to make sure we can till exist here
-		if (!IsSupported(_world, _pos, PacketData::FaceDirection(_meta)))
+		if (!IsSupported(_world, _pos, Direction::Value(_meta)))
 			BreakAndDropBlock(_world, _pos);
 	};
 	blockBehaviors[BLOCK_LADDER].onBlockPlaced = [](WorldManager& _world, Int3 _pos, Entity& _placer,
-	                                                PacketData::FaceDirection _face, BlockType _blockId,
-	                                                uint8_t _meta) -> bool {
+	                                                Direction::Value _face, BlockType _blockId, uint8_t _meta) -> bool {
 		Int3 targetPos = _pos;
 		const Int3 sourceBlock = Blocks::GetSourceBlockFromFace(_pos, _face);
 		if (_world.GetBlockId(sourceBlock) == BLOCK_SNOW_LAYER)
 			targetPos = sourceBlock;
 
-		static constexpr std::array<PacketData::FaceDirection, 4> CHECK_ORDER = { PacketData::FaceDirection::Z_MINUS,
-			                                                                      PacketData::FaceDirection::Z_PLUS,
-			                                                                      PacketData::FaceDirection::X_MINUS,
-			                                                                      PacketData::FaceDirection::X_PLUS };
+		static constexpr std::array<Direction::Value, 4> CHECK_ORDER = {
+			Direction::Value::Z_MINUS, Direction::Value::Z_PLUS, Direction::Value::X_MINUS, Direction::Value::X_PLUS
+		};
 
 		if (_face >= 2 && IsSupported(_world, _pos, _face)) {
 			return GenericPlace(_world, _pos, _placer, _face, _blockId, uint8_t(_face));
 		}
 
-		for (PacketData::FaceDirection dir : CHECK_ORDER) {
+		for (Direction::Value dir : CHECK_ORDER) {
 			if (IsSupported(_world, _pos, dir)) {
 				return GenericPlace(_world, _pos, _placer, _face, _blockId, uint8_t(dir));
 			}
@@ -908,7 +905,7 @@ void RegisterBlockBehaviors() {
 	};
 
 	blockBehaviors[BLOCK_REDSTONE_TORCH_ON].onBlockPlaced = [](WorldManager& _world, Int3 _pos, Entity& _placer,
-	                                                           PacketData::FaceDirection _face, BlockType _blockId,
+	                                                           Direction::Value _face, BlockType _blockId,
 	                                                           uint8_t _meta) -> bool {
 		if (_world.GetBlockId(Blocks::GetSourceBlockFromFace(_pos, _face)) == BLOCK_SNOW_LAYER)
 			_pos = Blocks::GetSourceBlockFromFace(_pos, _face);
@@ -919,18 +916,18 @@ void RegisterBlockBehaviors() {
 	};
 
 	blockBehaviors[BLOCK_REDSTONE_TORCH_ON].onBlockAdded = [](WorldManager& _world, Int3 _pos) -> void {
-		const auto currentFace = static_cast<PacketData::FaceDirection>(6 - _world.GetMetadata(_pos));
+		const auto currentFace = static_cast<Direction::Value>(6 - _world.GetMetadata(_pos));
 		if (CanTorchAttachTo(_world, _pos, currentFace))
 			return; // Already valid
 
 		// Matches vanilla order
-		static constexpr std::array<PacketData::FaceDirection, 5> CHECK_ORDER = {
-			PacketData::FaceDirection::X_PLUS, PacketData::FaceDirection::X_MINUS, PacketData::FaceDirection::Z_PLUS,
-			PacketData::FaceDirection::Z_MINUS, PacketData::FaceDirection::Y_PLUS
+		static constexpr std::array<Direction::Value, 5> CHECK_ORDER = {
+			Direction::Value::X_PLUS, Direction::Value::X_MINUS, Direction::Value::Z_PLUS, Direction::Value::Z_MINUS,
+			Direction::Value::Y_PLUS
 		};
 
 		// Attach to the first support block we find
-		for (PacketData::FaceDirection face : CHECK_ORDER) {
+		for (Direction::Value face : CHECK_ORDER) {
 			if (CanTorchAttachTo(_world, _pos, face)) {
 				_world.SetMeta(_pos, 6 - face);
 				return;
@@ -943,7 +940,7 @@ void RegisterBlockBehaviors() {
 	blockBehaviors[BLOCK_REDSTONE_TORCH_ON].onNeighborBlockChange = [](WorldManager& _world, Int3 _pos,
 	                                                                   BlockType _blockId) -> void {
 		uint8_t meta = _world.GetMetadata(_pos);
-		auto supportFace = static_cast<PacketData::FaceDirection>(6 - meta);
+		auto supportFace = static_cast<Direction::Value>(6 - meta);
 		if (!CanTorchAttachTo(_world, _pos, supportFace)) {
 			BreakAndDropBlock(_world, _pos);
 			return;
@@ -955,13 +952,13 @@ void RegisterBlockBehaviors() {
 
 	blockBehaviors[BLOCK_REDSTONE_TORCH_ON].onTick = [](WorldManager& _world, Int3 _pos, uint8_t _meta,
 	                                                    Java::Random& _random) -> void {
-		auto supportFace = static_cast<PacketData::FaceDirection>(6 - _meta);
+		auto supportFace = static_cast<Direction::Value>(6 - _meta);
 		if (!CanTorchAttachTo(_world, _pos, supportFace)) {
 			BreakAndDropBlock(_world, _pos);
 			return;
 		}
 
-		Int3 supportPos = Blocks::GetAdjacentBlockPos(_pos, PacketData::OppositeFace(supportFace));
+		Int3 supportPos = _pos.WithOffset(PacketData::OppositeFace(supportFace));
 
 		// turn OFF the instant the block it's mounted on is powered
 		if (RedstoneManager::GetBlockPowerProfile(_world, supportPos).powered) {
@@ -970,16 +967,16 @@ void RegisterBlockBehaviors() {
 	};
 
 	blockBehaviors[BLOCK_REDSTONE_TORCH_OFF].onBlockAdded = [](WorldManager& _world, Int3 _pos) -> void {
-		auto currentFace = static_cast<PacketData::FaceDirection>(6 - _world.GetMetadata(_pos));
+		auto currentFace = static_cast<Direction::Value>(6 - _world.GetMetadata(_pos));
 		if (CanTorchAttachTo(_world, _pos, currentFace))
 			return; // Already valid
 
-		static constexpr std::array<PacketData::FaceDirection, 5> CHECK_ORDER = {
-			PacketData::FaceDirection::X_PLUS, PacketData::FaceDirection::X_MINUS, PacketData::FaceDirection::Z_PLUS,
-			PacketData::FaceDirection::Z_MINUS, PacketData::FaceDirection::Y_PLUS
+		static constexpr std::array<Direction::Value, 5> CHECK_ORDER = {
+			Direction::Value::X_PLUS, Direction::Value::X_MINUS, Direction::Value::Z_PLUS, Direction::Value::Z_MINUS,
+			Direction::Value::Y_PLUS
 		};
 
-		for (PacketData::FaceDirection face : CHECK_ORDER) {
+		for (Direction::Value face : CHECK_ORDER) {
 			if (CanTorchAttachTo(_world, _pos, face)) {
 				_world.SetMeta(_pos, 6 - face);
 				return;
@@ -992,7 +989,7 @@ void RegisterBlockBehaviors() {
 	blockBehaviors[BLOCK_REDSTONE_TORCH_OFF].onNeighborBlockChange = [](WorldManager& _world, Int3 _pos,
 	                                                                    BlockType _blockId) -> void {
 		uint8_t meta = _world.GetMetadata(_pos);
-		auto supportFace = static_cast<PacketData::FaceDirection>(6 - meta);
+		auto supportFace = static_cast<Direction::Value>(6 - meta);
 		if (!CanTorchAttachTo(_world, _pos, supportFace)) {
 			BreakAndDropBlock(_world, _pos);
 			return;
@@ -1003,13 +1000,13 @@ void RegisterBlockBehaviors() {
 
 	blockBehaviors[BLOCK_REDSTONE_TORCH_OFF].onTick = [](WorldManager& _world, Int3 _pos, uint8_t _meta,
 	                                                     Java::Random& _random) -> void {
-		auto supportFace = static_cast<PacketData::FaceDirection>(6 - _meta);
+		auto supportFace = static_cast<Direction::Value>(6 - _meta);
 		if (!CanTorchAttachTo(_world, _pos, supportFace)) {
 			BreakAndDropBlock(_world, _pos);
 			return;
 		}
 
-		Int3 supportPos = Blocks::GetAdjacentBlockPos(_pos, PacketData::OppositeFace(supportFace));
+		Int3 supportPos = _pos.WithOffset(PacketData::OppositeFace(supportFace));
 
 		// An unlit torch turns back ON the instant the block it's mounted on is no longer powered
 		if (!RedstoneManager::GetBlockPowerProfile(_world, supportPos).powered) {
@@ -1018,7 +1015,7 @@ void RegisterBlockBehaviors() {
 	};
 
 	blockBehaviors[BLOCK_REDSTONE_REPEATER_OFF].onBlockPlaced = [](WorldManager& _world, Int3 _pos, Entity& _placer,
-	                                                               PacketData::FaceDirection _face, BlockType _blockId,
+	                                                               Direction::Value _face, BlockType _blockId,
 	                                                               uint8_t _meta) -> bool {
 		const auto dir = Direction::FromAngle(_placer.rotationYaw);
 		if (!CanRedstoneComponentStay(_world, _pos) ||
@@ -1032,7 +1029,7 @@ void RegisterBlockBehaviors() {
 		return true;
 	};
 	blockBehaviors[BLOCK_REDSTONE].onBlockPlaced = [](WorldManager& _world, Int3 _pos, Entity& _placer,
-	                                                  PacketData::FaceDirection _face, BlockType _blockId,
+	                                                  Direction::Value _face, BlockType _blockId,
 	                                                  uint8_t _meta) -> bool {
 		if (!CanRedstoneComponentStay(_world, _pos) || !GenericPlace(_world, _pos, _placer, _face, _blockId, _meta))
 			return false;
@@ -1092,14 +1089,13 @@ void RegisterBlockBehaviors() {
 	};
 
 	blockBehaviors[BLOCK_REDSTONE_REPEATER_ON].onBlockPlaced = [](WorldManager& _world, Int3 _pos, Entity& _placer,
-	                                                              PacketData::FaceDirection _face, BlockType _blockId,
+	                                                              Direction::Value _face, BlockType _blockId,
 	                                                              uint8_t _meta) -> bool {
 		return blockBehaviors[BLOCK_REDSTONE_REPEATER_OFF].onBlockPlaced(_world, _pos, _placer, _face, _blockId, _meta);
 	};
 
 	blockBehaviors[BLOCK_TORCH].onBlockPlaced = [](WorldManager& _world, Int3 _pos, Entity& _placer,
-	                                               PacketData::FaceDirection _face, BlockType _blockId,
-	                                               uint8_t _meta) -> bool {
+	                                               Direction::Value _face, BlockType _blockId, uint8_t _meta) -> bool {
 		if (_world.GetBlockId(Blocks::GetSourceBlockFromFace(_pos, _face)) == BLOCK_SNOW_LAYER)
 			_pos = Blocks::GetSourceBlockFromFace(_pos, _face);
 		if (CanTorchAttachTo(_world, _pos, _face)) {
@@ -1109,18 +1105,18 @@ void RegisterBlockBehaviors() {
 	};
 
 	blockBehaviors[BLOCK_TORCH].onBlockAdded = [](WorldManager& _world, Int3 _pos) -> void {
-		auto currentFace = static_cast<PacketData::FaceDirection>(6 - _world.GetMetadata(_pos));
+		auto currentFace = static_cast<Direction::Value>(6 - _world.GetMetadata(_pos));
 		if (CanTorchAttachTo(_world, _pos, currentFace))
 			return; // Already valid
 
 		// Matches vanilla order
-		static constexpr std::array<PacketData::FaceDirection, 5> CHECK_ORDER = {
-			PacketData::FaceDirection::X_PLUS, PacketData::FaceDirection::X_MINUS, PacketData::FaceDirection::Z_PLUS,
-			PacketData::FaceDirection::Z_MINUS, PacketData::FaceDirection::Y_PLUS
+		static constexpr std::array<Direction::Value, 5> CHECK_ORDER = {
+			Direction::Value::X_PLUS, Direction::Value::X_MINUS, Direction::Value::Z_PLUS, Direction::Value::Z_MINUS,
+			Direction::Value::Y_PLUS
 		};
 
 		// Attach to the first support block we find
-		for (PacketData::FaceDirection face : CHECK_ORDER) {
+		for (Direction::Value face : CHECK_ORDER) {
 			if (CanTorchAttachTo(_world, _pos, face)) {
 				_world.SetMeta(_pos, 6 - face);
 				return;
@@ -1132,15 +1128,15 @@ void RegisterBlockBehaviors() {
 
 	blockBehaviors[BLOCK_TORCH].onNeighborBlockChange = [](WorldManager& _world, Int3 _pos, BlockType _blockId) -> void {
 		uint8_t meta = _world.GetMetadata(_pos);
-		auto supportFace = static_cast<PacketData::FaceDirection>(6 - meta);
+		auto supportFace = static_cast<Direction::Value>(6 - meta);
 		if (!CanTorchAttachTo(_world, _pos, supportFace))
 			BreakAndDropBlock(_world, _pos);
 	};
 
-	auto onDoorPlace = [](WorldManager& _world, Int3 _pos, Entity& _placer, PacketData::FaceDirection _face,
-	                      BlockType _blockId, uint8_t _meta) -> bool {
+	auto onDoorPlace = [](WorldManager& _world, Int3 _pos, Entity& _placer, Direction::Value _face, BlockType _blockId,
+	                      uint8_t _meta) -> bool {
 		// Doors can only be placed by clicking the top face of a block
-		if (_face != PacketData::FaceDirection::Y_PLUS)
+		if (_face != Direction::Value::Y_PLUS)
 			return false;
 
 		// _pos is already the target cell
@@ -1223,10 +1219,9 @@ void RegisterBlockBehaviors() {
 	};
 
 	blockBehaviors[BLOCK_BED].onBlockPlaced = [](WorldManager& _world, Int3 _pos, Entity& _placer,
-	                                             PacketData::FaceDirection _face, BlockType _blockId,
-	                                             uint8_t _meta) -> bool {
+	                                             Direction::Value _face, BlockType _blockId, uint8_t _meta) -> bool {
 		// Beds can only be placed by clicking the top face of a block
-		if (_face != PacketData::FaceDirection::Y_PLUS)
+		if (_face != Direction::Value::Y_PLUS)
 			return false;
 
 		// _pos is already the target cell
@@ -1327,8 +1322,7 @@ void RegisterBlockBehaviors() {
 		GenericBreak(_world, _pos, _destroyer);
 	};
 	blockBehaviors[BLOCK_LEAVES].onBlockPlaced = [](WorldManager& _world, Int3 _pos, Entity& _placer,
-	                                                PacketData::FaceDirection _face, BlockType _blockId,
-	                                                uint8_t _meta) -> bool {
+	                                                Direction::Value _face, BlockType _blockId, uint8_t _meta) -> bool {
 		// So leaves placed by players dont decay
 		return GenericPlace(_world, _pos, _placer, _face, _blockId, /*meta=*/_meta & 0b11);
 	};

--- a/src/bpp_shared/blocks/block_behaviors.h
+++ b/src/bpp_shared/blocks/block_behaviors.h
@@ -6,6 +6,7 @@
 */
 
 #pragma once
+#include "direction.h"
 
 #include "AABB.h"
 #include "block_shapes.h"

--- a/src/bpp_shared/blocks/block_behaviors.h
+++ b/src/bpp_shared/blocks/block_behaviors.h
@@ -20,7 +20,7 @@ struct PlayerSession;
 
 namespace Blocks {
 
-bool GenericPlace(WorldManager& _world, Int3 _pos, [[maybe_unused]] Entity& _placer, PacketData::FaceDirection _face,
+bool GenericPlace(WorldManager& _world, Int3 _pos, [[maybe_unused]] Entity& _placer, Direction::Value _face,
                   BlockType _blockId, uint8_t _meta);
 void GenericBreak(WorldManager& _world, Int3 _pos, Entity& _destroyer);
 void GenericExplode(WorldManager& _world, Int3 _pos);
@@ -58,8 +58,8 @@ struct BlockBehavior {
 
 	// Called when block is placed by a player
 	// Returns if the placement was successful
-	bool (*onBlockPlaced)(WorldManager& _world, Int3 _pos, Entity& _placer, PacketData::FaceDirection _face,
-	                      BlockType _blockId, uint8_t _meta) = GenericPlace;
+	bool (*onBlockPlaced)(WorldManager& _world, Int3 _pos, Entity& _placer, Direction::Value _face, BlockType _blockId,
+	                      uint8_t _meta) = GenericPlace;
 
 	// Called when player breaks the block
 	void (*onBlockDestroyedByPlayer)(WorldManager& _world, Int3 _pos, Entity& _destroyer) = GenericBreak;

--- a/src/bpp_shared/blocks/block_properties.cpp
+++ b/src/bpp_shared/blocks/block_properties.cpp
@@ -154,14 +154,14 @@ bool CanCactusSurviveAt(WorldManager& _world, Int3 _pos) {
 	return canGrowOnBlock && adjacentBlocksClear;
 }
 
-bool CanTorchAttachTo(WorldManager& _world, Int3 _pos, PacketData::FaceDirection _face) {
-	if (_face == PacketData::FaceDirection::Y_MINUS)
+bool CanTorchAttachTo(WorldManager& _world, Int3 _pos, Direction::Value _face) {
+	if (_face == Direction::Value::Down)
 		return false;
 
-	Int3 support = GetAdjacentBlockPos(_pos, OppositeFace(_face));
+	Int3 support = _pos.WithOffset(Direction::Opposite(_face));
 
 	return _world.IsBlockNormalCube(support) ||
-	       (_face == PacketData::FaceDirection::Y_PLUS && _world.GetBlockId(support) == BLOCK_FENCE);
+	       (_face == Direction::Value::Up && _world.GetBlockId(support) == BLOCK_FENCE);
 }
 
 // Some fluid specific stuff
@@ -955,31 +955,27 @@ void RegisterBlockProperties() {
 	};
 
 	// Redstone Torch (off)
-	blockProperties[BlockType::BLOCK_REDSTONE_TORCH_OFF] = {
-		.material = Material::Circuits(),
-		.stepSound = StepSound::Wood,
-		.lightOpacity = 0,
-		.hardness = 0.0f,
-		.isCollidable = false,
-		.isOpaqueCube = false,
-		.isNormalCube = false,
-		.renderAsNormalBlock = false,
-		.ticksOnLoad = true
-	};
+	blockProperties[BlockType::BLOCK_REDSTONE_TORCH_OFF] = { .material = Material::Circuits(),
+		                                                     .stepSound = StepSound::Wood,
+		                                                     .lightOpacity = 0,
+		                                                     .hardness = 0.0f,
+		                                                     .isCollidable = false,
+		                                                     .isOpaqueCube = false,
+		                                                     .isNormalCube = false,
+		                                                     .renderAsNormalBlock = false,
+		                                                     .ticksOnLoad = true };
 
 	// Redstone Torch (on)
-	blockProperties[BlockType::BLOCK_REDSTONE_TORCH_ON] = {
-		.material = Material::Circuits(),
-		.stepSound = StepSound::Wood,
-		.lightEmission = 7,
-		.lightOpacity = 0,
-		.hardness = 0.0f,
-		.isCollidable = false,
-		.isOpaqueCube = false,
-		.isNormalCube = false,
-		.renderAsNormalBlock = false,
-		.ticksOnLoad = true
-	};
+	blockProperties[BlockType::BLOCK_REDSTONE_TORCH_ON] = { .material = Material::Circuits(),
+		                                                    .stepSound = StepSound::Wood,
+		                                                    .lightEmission = 7,
+		                                                    .lightOpacity = 0,
+		                                                    .hardness = 0.0f,
+		                                                    .isCollidable = false,
+		                                                    .isOpaqueCube = false,
+		                                                    .isNormalCube = false,
+		                                                    .renderAsNormalBlock = false,
+		                                                    .ticksOnLoad = true };
 
 	// Stone Button
 	blockProperties[BlockType::BLOCK_BUTTON_STONE] = {

--- a/src/bpp_shared/blocks/block_properties.cpp
+++ b/src/bpp_shared/blocks/block_properties.cpp
@@ -154,12 +154,21 @@ bool CanCactusSurviveAt(WorldManager& _world, Int3 _pos) {
 	return canGrowOnBlock && adjacentBlocksClear;
 }
 
+/**
+ * @brief Says if a torch can attach to the block its placed on
+ * 
+ * @param _world Active world
+ * @param _pos The position of the torch
+ * @param _face The direction the torch is pointing out towards
+ * @return true The torch can be placed
+ * @return false The torch cannot be placed
+ */
 bool CanTorchAttachTo(WorldManager& _world, Int3 _pos, Direction::Value _face) {
+	// Torches cannot be placed on the ceiling
 	if (_face == Direction::Value::Down)
 		return false;
-
+	// Get supporting block
 	Int3 support = _pos.WithOffset(Direction::Opposite(_face));
-
 	return _world.IsBlockNormalCube(support) ||
 	       (_face == Direction::Value::Up && _world.GetBlockId(support) == BLOCK_FENCE);
 }

--- a/src/bpp_shared/blocks/block_properties.h
+++ b/src/bpp_shared/blocks/block_properties.h
@@ -5,6 +5,7 @@
  *
 */
 #pragma once
+#include "direction.h"
 #include "materials.h"
 #include "packet_data.h"
 #include <numeric_structs.h>

--- a/src/bpp_shared/blocks/block_properties.h
+++ b/src/bpp_shared/blocks/block_properties.h
@@ -18,7 +18,7 @@ namespace Blocks {
 
 bool CanSugarcaneSurviveAt(WorldAccess& _world, Int3 _pos);
 bool CanCropsSurviveAt(WorldAccess& _world, Int3 _pos);
-bool CanTorchAttachTo(WorldManager& _world, Int3 _pos, PacketData::FaceDirection _face);
+bool CanTorchAttachTo(WorldManager& _world, Int3 _pos, Direction::Value _face);
 float GetFluidPercentAir(uint8_t _meta);
 void BreakAndDropBlock(WorldManager& _world, Int3 _pos);
 void BreakAndDropBlockWithChance(WorldManager& _world, Int3 _pos, float _chance);
@@ -28,32 +28,6 @@ bool CanFallAt(WorldAccess& _world, Int3 _position);
 bool CanGenericPlantSurviveAt(WorldAccess& _world, Int3 _pos);
 bool CanMushroomSurviveAt(WorldAccess& _world, Int3 _pos);
 bool CanCactusSurviveAt(WorldManager& _world, Int3 _pos);
-
-constexpr Int3 GetSourceBlockFromFace(Int3 _pos, PacketData::FaceDirection _face) {
-	switch (_face) {
-	case PacketData::FaceDirection::Y_MINUS:
-		++_pos.y;
-		break;
-	case PacketData::FaceDirection::Y_PLUS:
-		--_pos.y;
-		break;
-	case PacketData::FaceDirection::Z_MINUS:
-		++_pos.z;
-		break;
-	case PacketData::FaceDirection::Z_PLUS:
-		--_pos.z;
-		break;
-	case PacketData::FaceDirection::X_MINUS:
-		++_pos.x;
-		break;
-	case PacketData::FaceDirection::X_PLUS:
-		--_pos.x;
-		break;
-	default:
-		break;
-	}
-	return _pos;
-}
 
 enum class StepSound : uint8_t {
 	Stone, // default, also metal (different pitch)

--- a/src/bpp_shared/blocks/block_properties.h
+++ b/src/bpp_shared/blocks/block_properties.h
@@ -29,32 +29,6 @@ bool CanGenericPlantSurviveAt(WorldAccess& _world, Int3 _pos);
 bool CanMushroomSurviveAt(WorldAccess& _world, Int3 _pos);
 bool CanCactusSurviveAt(WorldManager& _world, Int3 _pos);
 
-constexpr Int3 GetAdjacentBlockPos(Int3 _pos, PacketData::FaceDirection _face) {
-	switch (_face) {
-	case PacketData::FaceDirection::Y_MINUS:
-		--_pos.y;
-		break;
-	case PacketData::FaceDirection::Y_PLUS:
-		++_pos.y;
-		break;
-	case PacketData::FaceDirection::Z_MINUS:
-		--_pos.z;
-		break;
-	case PacketData::FaceDirection::Z_PLUS:
-		++_pos.z;
-		break;
-	case PacketData::FaceDirection::X_MINUS:
-		--_pos.x;
-		break;
-	case PacketData::FaceDirection::X_PLUS:
-		++_pos.x;
-		break;
-	default:
-		break;
-	}
-	return _pos;
-}
-
 constexpr Int3 GetSourceBlockFromFace(Int3 _pos, PacketData::FaceDirection _face) {
 	switch (_face) {
 	case PacketData::FaceDirection::Y_MINUS:

--- a/src/bpp_shared/direction.h
+++ b/src/bpp_shared/direction.h
@@ -7,6 +7,7 @@
 
 #pragma once
 #include "./helpers/java/java_math.h"
+#include <string_view>
 namespace Direction {
 
 enum class Value : uint8_t {
@@ -103,6 +104,25 @@ constexpr bool IsVertical(const Value _dir) {
 		return true;
 	default:
 		return false;
+	}
+}
+
+constexpr std::string_view Str(const Value _dir) {
+	switch (_dir) {
+	case Value::North:
+		return "North";
+	case Value::South:
+		return "South";
+	case Value::East:
+		return "East";
+	case Value::West:
+		return "West";
+	case Value::Up:
+		return "Up";
+	case Value::Down:
+		return "Down";
+	default:
+		return "INVALID";
 	}
 }
 

--- a/src/bpp_shared/direction.h
+++ b/src/bpp_shared/direction.h
@@ -10,61 +10,100 @@
 namespace Direction {
 
 enum class Value : uint8_t {
-    None,
-    North,
-    South,
-    East,
-    West,
-    Up,
-    Down
+	None,
+	North,
+	South,
+	East,
+	West,
+	Up,
+	Down
 };
 
 constexpr Value Opposite(const Value _dir) {
-    switch (_dir) {
-    case Value::North: return Value::South;
-    case Value::South: return Value::North;
-    case Value::East:  return Value::West;
-    case Value::West:  return Value::East;
-    case Value::Up:    return Value::Down;
-    case Value::Down:  return Value::Up;
-    default:              return _dir;
-    }
+	switch (_dir) {
+	case Value::North:
+		return Value::South;
+	case Value::South:
+		return Value::North;
+	case Value::East:
+		return Value::West;
+	case Value::West:
+		return Value::East;
+	case Value::Up:
+		return Value::Down;
+	case Value::Down:
+		return Value::Up;
+	default:
+		return _dir;
+	}
 }
 
 // Rotating around the vertical (Y) axis, as seen from above.
 constexpr Value ToLeft(const Value _dir) {
-    switch (_dir) {
-    case Value::North: return Value::West;
-    case Value::South: return Value::East;
-    case Value::East:  return Value::North;
-    case Value::West:  return Value::South;
-    default:              return _dir;
-    }
+	switch (_dir) {
+	case Value::North:
+		return Value::West;
+	case Value::South:
+		return Value::East;
+	case Value::East:
+		return Value::North;
+	case Value::West:
+		return Value::South;
+	default:
+		return _dir;
+	}
 }
 
 constexpr Value ToRight(const Value _dir) {
-    switch (_dir) {
-    case Value::North: return Value::East;
-    case Value::South: return Value::West;
-    case Value::East:  return Value::South;
-    case Value::West:  return Value::North;
-    default:              return _dir;
-    }
+	switch (_dir) {
+	case Value::North:
+		return Value::East;
+	case Value::South:
+		return Value::West;
+	case Value::East:
+		return Value::South;
+	case Value::West:
+		return Value::North;
+	default:
+		return _dir;
+	}
 }
 
 constexpr Value FromAngle(const float _yaw) {
-    switch(MathHelper::FloorDouble((_yaw + 180.0f) * 4.0f / 360.0f - 0.5f) & 0b11) {
-        case 0:
-            return Value::East;
-        case 1:
-            return Value::South;
-        case 2:
-            return Value::West;
-        case 3:
-            return Value::North;
-        default:
-            return Value::None;
-    }
+	switch (MathHelper::FloorDouble((_yaw + 180.0f) * 4.0f / 360.0f - 0.5f) & 0b11) {
+	case 0:
+		return Value::East;
+	case 1:
+		return Value::South;
+	case 2:
+		return Value::West;
+	case 3:
+		return Value::North;
+	default:
+		return Value::None;
+	}
 }
 
+constexpr bool IsHorizontal(const Value _dir) {
+	switch (_dir) {
+	case Value::North:
+	case Value::South:
+	case Value::East:
+	case Value::West:
+		return true;
+	default:
+		return false;
+	}
 }
+
+constexpr bool IsVertical(const Value _dir) {
+	switch (_dir) {
+	case Value::Up:
+	case Value::Down:
+		return true;
+	default:
+		return false;
+	}
+}
+
+} // namespace Direction

--- a/src/bpp_shared/enums/network/packet_data.h
+++ b/src/bpp_shared/enums/network/packet_data.h
@@ -31,13 +31,6 @@ enum FaceDirection : int8_t {
 	X_PLUS = 5
 };
 
-constexpr inline FaceDirection OppositeFace(FaceDirection _face) {
-	if (_face == INVALID_USE)
-		return _face;
-
-	return static_cast<FaceDirection>(static_cast<int8_t>(_face) ^ 1);
-}
-
 // Used by the Interact with Block Packet (0x11)
 enum BlockInteraction : uint8_t {
 	SLEEPING = 0

--- a/src/bpp_shared/helpers/direction_fixer.h
+++ b/src/bpp_shared/helpers/direction_fixer.h
@@ -41,13 +41,13 @@ enum DirectionBlockType : size_t {
 // Maps the metadata value to a direction value
 static constexpr Direction::Value META_TO_DIRECTION_LUT[MAX_DIRECTION_BLOCK_TYPE][0b111]{
 	// Torches
-	{ Direction::Value::None, Direction::Value::West, Direction::Value::East, Direction::Value::South,
+	{ Direction::Value::None, Direction::Value::East, Direction::Value::West, Direction::Value::South,
 	  Direction::Value::North, Direction::Value::Up, Direction::Value::None },
 	// Levers
-	{ Direction::Value::None, Direction::Value::West, Direction::Value::East, Direction::Value::South,
+	{ Direction::Value::None, Direction::Value::East, Direction::Value::West, Direction::Value::South,
 	  Direction::Value::North, Direction::Value::Up, Direction::Value::Up },
 	// Buttons
-	{ Direction::Value::None, Direction::Value::West, Direction::Value::East, Direction::Value::South,
+	{ Direction::Value::None, Direction::Value::East, Direction::Value::West, Direction::Value::South,
 	  Direction::Value::North, Direction::Value::None, Direction::Value::None },
 	// Stairs
 	{ Direction::Value::East, Direction::Value::West, Direction::Value::South, Direction::Value::North,
@@ -86,13 +86,13 @@ static constexpr Direction::Value GetDirectionFromMeta(const BlockType _type, co
 	switch (_type) {
 	case BLOCK_TORCH:
 	case BLOCK_REDSTONE_TORCH_OFF:
-	case BLOCK_ORE_REDSTONE_ON:
-		return META_TO_DIRECTION_LUT[DirectionBlockType::Torch][_meta & 0b11];
+	case BLOCK_REDSTONE_TORCH_ON:
+		return META_TO_DIRECTION_LUT[DirectionBlockType::Torch][_meta & 0b111];
 	case BLOCK_LEVER:
 		// Note: Does not differentiate North-South/East-West direction
 		return META_TO_DIRECTION_LUT[DirectionBlockType::Lever][_meta & 0b111];
 	case BLOCK_BUTTON_STONE:
-		return META_TO_DIRECTION_LUT[DirectionBlockType::Button][_meta & 0b11];
+		return META_TO_DIRECTION_LUT[DirectionBlockType::Button][_meta & 0b111];
 	case BLOCK_STAIRS_COBBLESTONE:
 	case BLOCK_STAIRS_WOOD:
 		return META_TO_DIRECTION_LUT[DirectionBlockType::Stairs][_meta & 0b11];
@@ -138,7 +138,7 @@ static constexpr uint8_t GetMetaFromDirection(const BlockType _type, const Direc
 	switch (_type) {
 	case BLOCK_TORCH:
 	case BLOCK_REDSTONE_TORCH_OFF:
-	case BLOCK_ORE_REDSTONE_ON:
+	case BLOCK_REDSTONE_TORCH_ON:
 	case BLOCK_LEVER:
 		switch (_dir) {
 		case Direction::Value::North:

--- a/src/bpp_shared/helpers/direction_fixer.h
+++ b/src/bpp_shared/helpers/direction_fixer.h
@@ -146,9 +146,9 @@ static constexpr uint8_t GetMetaFromDirection(const BlockType _type, const Direc
 		case Direction::Value::South:
 			return 3;
 		case Direction::Value::East:
-			return 2;
-		case Direction::Value::West:
 			return 1;
+		case Direction::Value::West:
+			return 2;
 		// Note: For levers, handle North-South/East-West direction separately, defaults to North-South!
 		case Direction::Value::Up:
 			return 5;

--- a/src/bpp_shared/helpers/raycast.h
+++ b/src/bpp_shared/helpers/raycast.h
@@ -5,6 +5,7 @@
 */
 
 #pragma once
+#include "../direction.h"
 #include "world.h"
 #include <cmath>
 #include <limits>
@@ -19,14 +20,14 @@ struct RayCastResult {
 	bool hit = false;
 	Block hitBlock = {};
 	Int3 blockPosition = {};
-	PacketData::FaceDirection face = PacketData::FaceDirection::INVALID_USE;
+	Direction::Value face = Direction::Value::None;
 };
 
 // Name is a bit obvious isn't it?
 namespace Raycast {
 
 inline bool ClipRayAABB(const Vec3& _origin, const Vec3& _dir, double _maxDist, const AABB& _box, double& _outT,
-                        PacketData::FaceDirection& _outFace) {
+                        Direction::Value& _outFace) {
 	double originArr[3] = { _origin.x, _origin.y, _origin.z };
 	double dirArr[3] = { _dir.x, _dir.y, _dir.z };
 	double boxMin[3] = { _box.minX, _box.minY, _box.minZ };
@@ -75,13 +76,13 @@ inline bool ClipRayAABB(const Vec3& _origin, const Vec3& _dir, double _maxDist, 
 	double d = dirArr[hitAxis];
 	switch (hitAxis) {
 	case 0:
-		_outFace = (d > 0) ? PacketData::FaceDirection::X_MINUS : PacketData::FaceDirection::X_PLUS;
+		_outFace = (d > 0) ? Direction::Value::West : Direction::Value::East;
 		break;
 	case 1:
-		_outFace = (d > 0) ? PacketData::FaceDirection::Y_MINUS : PacketData::FaceDirection::Y_PLUS;
+		_outFace = (d > 0) ? Direction::Value::Down : Direction::Value::Up;
 		break;
 	default:
-		_outFace = (d > 0) ? PacketData::FaceDirection::Z_MINUS : PacketData::FaceDirection::Z_PLUS;
+		_outFace = (d > 0) ? Direction::Value::North : Direction::Value::South;
 		break;
 	}
 	return true;
@@ -150,7 +151,7 @@ inline RayCastResult Raycast(WorldManager& _world, Vec3 _startPos, Vec3 _endPos,
 					AABB worldBox = localBox.Offset(x, y, z);
 
 					double hitT;
-					PacketData::FaceDirection hitFace;
+					Direction::Value hitFace;
 					if (ClipRayAABB(_startPos, dir, dist, worldBox, hitT, hitFace)) {
 						result.hit = true;
 						result.hitBlock = { id, meta };

--- a/src/bpp_shared/items/item_properties.h
+++ b/src/bpp_shared/items/item_properties.h
@@ -6,6 +6,7 @@
 */
 
 #pragma once
+#include "direction.h"
 #include "base_types.h"
 #include "items.h"
 #include "logger.h"

--- a/src/bpp_shared/items/item_properties.h
+++ b/src/bpp_shared/items/item_properties.h
@@ -36,7 +36,7 @@ enum ArmorPiece {
 struct ItemBehavior {
 	void (*onUse)(PlayerSession& _session, ItemStack* _stack, Entity& _target) = nullptr;
 	void (*onBlockUse)(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user,
-	                   PacketData::FaceDirection _face) = nullptr;
+	                   Direction::Value _face) = nullptr;
 	void (*onStartHolding)(ItemStack* _stack, PlayerSession& _session) = nullptr;
 	void (*whileHeld)(ItemStack* _stack, PlayerSession& _session, Server& _server) = nullptr;
 	void (*onStopHolding)(ItemStack* _stack) = nullptr;

--- a/src/bpp_shared/items/tool_item_properties.cpp
+++ b/src/bpp_shared/items/tool_item_properties.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  *
 */
+#include "../helpers/direction_fixer.h"
 #include "blocks.h"
 #include "item_map.h"
 #include "item_properties.h"
@@ -240,7 +241,7 @@ void RegisterAll() {
 		if (_face == Direction::Value::Up)
 			_world.SetBlock(placePos, BLOCK_SIGN); //TODO: facing meta
 		else
-			_world.SetBlock(placePos, BLOCK_SIGN_WALL, _face);
+			_world.SetBlock(placePos, BLOCK_SIGN_WALL, GetMetaFromDirection(BLOCK_SIGN_WALL, _face));
 
 		_stack->DecrementCount(1);
 	};

--- a/src/bpp_shared/items/tool_item_properties.cpp
+++ b/src/bpp_shared/items/tool_item_properties.cpp
@@ -215,8 +215,8 @@ void RegisterAll() {
 	itemBehavior[MUSHROOM_STEW].onUse = EatFood;
 
 	itemBehavior[SUGARCANE].onBlockUse = [](WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user,
-	                                        PacketData::FaceDirection _face) {
-		Int3 placePos = Blocks::GetAdjacentBlockPos(_pos, _face);
+	                                        Direction::Value _face) {
+		Int3 placePos = _pos.WithOffset(_face);
 		if (!Blocks::CanSugarcaneSurviveAt(_world, placePos))
 			return;
 
@@ -225,8 +225,8 @@ void RegisterAll() {
 	};
 
 	itemBehavior[SEEDS_WHEAT].onBlockUse = [](WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user,
-	                                          PacketData::FaceDirection _face) {
-		Int3 placePos = Blocks::GetAdjacentBlockPos(_pos, _face);
+	                                          Direction::Value _face) {
+		Int3 placePos = _pos.WithOffset(_face);
 		if (!Blocks::CanCropsSurviveAt(_world, placePos))
 			return;
 
@@ -235,9 +235,9 @@ void RegisterAll() {
 	};
 
 	itemBehavior[SIGN].onBlockUse = [](WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user,
-	                                   PacketData::FaceDirection _face) {
-		Int3 placePos = Blocks::GetAdjacentBlockPos(_pos, _face);
-		if (_face == PacketData::FaceDirection::Y_PLUS)
+	                                   Direction::Value _face) {
+		Int3 placePos = _pos.WithOffset(_face);
+		if (_face == Direction::Value::Up)
 			_world.SetBlock(placePos, BLOCK_SIGN); //TODO: facing meta
 		else
 			_world.SetBlock(placePos, BLOCK_SIGN_WALL, _face);
@@ -245,11 +245,10 @@ void RegisterAll() {
 		_stack->DecrementCount(1);
 	};
 
-	auto onDoorPlace = [](WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user,
-	                      PacketData::FaceDirection _face) {
+	auto onDoorPlace = [](WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user, Direction::Value _face) {
 		BlockType targetBlockType;
 		targetBlockType = _stack->id == DOOR_WOOD ? BLOCK_DOOR_WOOD : BLOCK_DOOR_IRON;
-		Int3 placePosition = Blocks::GetAdjacentBlockPos(_pos, _face);
+		Int3 placePosition = _pos.WithOffset(_face);
 		if (Blocks::blockBehaviors[targetBlockType].onBlockPlaced(_world, placePosition, _user, _face, targetBlockType,
 		                                                          0))
 			_stack->DecrementCount(1);
@@ -259,23 +258,23 @@ void RegisterAll() {
 	itemBehavior[DOOR_IRON].onBlockUse = onDoorPlace;
 
 	itemBehavior[REDSTONE_REPEATER].onBlockUse = [](WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user,
-	                                       PacketData::FaceDirection _face) {
-		Int3 placePos = Blocks::GetAdjacentBlockPos(_pos, _face);
+	                                                Direction::Value _face) {
+		Int3 placePos = _pos.WithOffset(_face);
 		if (Blocks::blockBehaviors[BLOCK_REDSTONE_REPEATER_OFF].onBlockPlaced(_world, placePos, _user, _face,
 		                                                                      BLOCK_REDSTONE_REPEATER_OFF, 0))
 			_stack->DecrementCount(1);
 	};
 
 	itemBehavior[REDSTONE].onBlockUse = [](WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user,
-	                                  PacketData::FaceDirection _face) {
-		Int3 placePos = Blocks::GetAdjacentBlockPos(_pos, _face);
+	                                       Direction::Value _face) {
+		Int3 placePos = _pos.WithOffset(_face);
 		if (Blocks::blockBehaviors[BLOCK_REDSTONE].onBlockPlaced(_world, placePos, _user, _face, BLOCK_REDSTONE, 0))
 			_stack->DecrementCount(1);
 	};
 
 	itemBehavior[BED].onBlockUse = [](WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user,
-	                                  PacketData::FaceDirection _face) {
-		Int3 placePos = Blocks::GetAdjacentBlockPos(_pos, _face);
+	                                  Direction::Value _face) {
+		Int3 placePos = _pos.WithOffset(_face);
 		if (Blocks::blockBehaviors[BLOCK_BED].onBlockPlaced(_world, placePos, _user, _face, BLOCK_BED, 0))
 			_stack->DecrementCount(1);
 	};

--- a/src/bpp_shared/items/tool_properties.cpp
+++ b/src/bpp_shared/items/tool_properties.cpp
@@ -369,7 +369,7 @@ void UseWaterBucket(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& 
 		return;
 	}
 
-	Int3 placePos = Blocks::GetAdjacentBlockPos(result.blockPosition, result.face);
+	Int3 placePos = result.blockPosition.WithOffset(result.face);
 	auto m = _world.GetMaterial(placePos);
 	if (m.isSolid) {
 		return; // can't place into solid ground
@@ -401,7 +401,7 @@ void UseLavaBucket(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _
 		return;
 	}
 
-	Int3 placePos = Blocks::GetAdjacentBlockPos(result.blockPosition, result.face);
+	Int3 placePos = result.blockPosition.WithOffset(result.face);
 	auto m = _world.GetMaterial(placePos);
 	if (m.isSolid) {
 		return; // can't place into solid ground

--- a/src/bpp_shared/items/tool_properties.cpp
+++ b/src/bpp_shared/items/tool_properties.cpp
@@ -316,7 +316,7 @@ void OnToolFinishMining(ItemStack* _stack, BlockType _targetBlock) {
 	}
 }
 
-void UseHoe(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user, PacketData::FaceDirection _face) {
+void UseHoe(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user, Direction::Value _face) {
 	BlockType b = _world.GetBlockId(_pos);
 	if (b == BLOCK_GRASS || b == BLOCK_DIRT) {
 		_world.SetBlock(_pos, BLOCK_FARMLAND);
@@ -324,7 +324,7 @@ void UseHoe(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user, P
 	HarmTool(_stack, 1);
 }
 
-void UseBucket(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user, PacketData::FaceDirection _face) {
+void UseBucket(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user, Direction::Value _face) {
 	float reach = 5.0f;
 	auto pe = dynamic_cast<PlayerEntity*>(&_user);
 	if (!pe) {
@@ -352,7 +352,7 @@ void UseBucket(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user
 	}
 }
 
-void UseWaterBucket(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user, PacketData::FaceDirection _face) {
+void UseWaterBucket(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user, Direction::Value _face) {
 	float reach = 5.0f;
 	auto pe = dynamic_cast<PlayerEntity*>(&_user);
 	if (!pe) {
@@ -384,7 +384,7 @@ void UseWaterBucket(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& 
 	_stack->id = Items::Id::BUCKET;
 }
 
-void UseLavaBucket(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user, PacketData::FaceDirection _face) {
+void UseLavaBucket(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user, Direction::Value _face) {
 	float reach = 5.0f;
 	auto pe = dynamic_cast<PlayerEntity*>(&_user);
 	if (!pe) {
@@ -411,13 +411,12 @@ void UseLavaBucket(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _
 	_stack->id = Items::Id::BUCKET;
 }
 
-void UseFlintAndSteel(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user,
-                      PacketData::FaceDirection _face) {
+void UseFlintAndSteel(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user, Direction::Value _face) {
 	if (_user.flags.isSneaking) {
 		TestSetGoal(_world, _stack, _pos, _face);
 		return;
 	}
-	_pos = Blocks::GetAdjacentBlockPos(_pos, _face);
+	_pos.Offset(_face);
 	_world.SetBlock(_pos, BLOCK_FIRE);
 	HarmTool(_stack, 1);
 }
@@ -437,7 +436,7 @@ void UseShears(WorldManager& _world, Entity& _targetEntity, ItemStack* _stack) {
 	HarmTool(_stack, 1);
 }
 
-void TestSetGoal(WorldManager& _world, ItemStack* _stack, Int3 _pos, PacketData::FaceDirection _face) {
+void TestSetGoal(WorldManager& _world, ItemStack* _stack, Int3 _pos, Direction::Value _face) {
 	Int3 topPos = _pos;
 	topPos.y += 1;
 	_world.SetBlock(topPos, BLOCK_AIR);

--- a/src/bpp_shared/items/tool_properties.h
+++ b/src/bpp_shared/items/tool_properties.h
@@ -121,16 +121,15 @@ float ShearsEffectiveness(ItemStack* _stack, BlockType _block);
 // Usage
 void HarmTool(ItemStack* _stack, const int _amount = 1);
 void OnToolFinishMining(ItemStack* _stack, BlockType _targetBlock);
-void UseHoe(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user, PacketData::FaceDirection _face);
-void UseFlintAndSteel(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user,
-                      PacketData::FaceDirection _face);
-void UseBucket(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user, PacketData::FaceDirection _face);
-void UseWaterBucket(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user, PacketData::FaceDirection _face);
-void UseLavaBucket(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user, PacketData::FaceDirection _face);
+void UseHoe(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user, Direction::Value _face);
+void UseFlintAndSteel(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user, Direction::Value _face);
+void UseBucket(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user, Direction::Value _face);
+void UseWaterBucket(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user, Direction::Value _face);
+void UseLavaBucket(WorldManager& _world, ItemStack* _stack, Int3 _pos, Entity& _user, Direction::Value _face);
 void UseShears(WorldManager& _world, Entity& _targetEntity, ItemStack* _stack);
 
 // Attack
-void TestSetGoal(WorldManager& _world, ItemStack* _stack, Int3 _pos, PacketData::FaceDirection _face);
+void TestSetGoal(WorldManager& _world, ItemStack* _stack, Int3 _pos, Direction::Value _face);
 void AttackWithItem(Entity& _targetEntity, Entity& _sourceEntity, ItemStack* _stack);
 
 struct ToolProperties {

--- a/src/bpp_shared/items/tool_properties.h
+++ b/src/bpp_shared/items/tool_properties.h
@@ -6,6 +6,7 @@
 */
 
 #pragma once
+#include "direction.h"
 
 #include "base_types.h"
 #include "blocks.h"


### PR DESCRIPTION
- Replaces the iffy and metadata dependent direction system with one unified system, used across the whole codebase
- Replaces all the erroneous uses of `PacketData::FaceDirection`
- Replaces all instances of Metadata value fuckery with easy to follow functions (e.g. `6 - meta` is now replaced with `Direction::Opposite(dir)`)
- Replaced all instances of `Blocks::GetAdjacentBlockPos` and `Blocks::GetSourceBlockFromFace` with equivalent `Offset` or `WithOffset` calls

Most directional blocks have been tested, such as:
- Torches
- Redstone Torches (On/Off)
- Redstone Repeaters (On/Off)
- Beds
- Doors
- Buttons
- Furnaces (Unlit)
- Wall Signs
- Ladders
- Trapdoors
- Stairs
- Pumpkins/Jack'o'Lanterns

All else still needs proper evaluation, such as tool/item usage or any blocks I may have forgotten. 

Piston directionality is not yet implemented, but that's what issue #12 is for.